### PR TITLE
Less boxing

### DIFF
--- a/src/AssertNet.Core.Tests/Assertions/Objects/BooleanAssertionTests.cs
+++ b/src/AssertNet.Core.Tests/Assertions/Objects/BooleanAssertionTests.cs
@@ -8,8 +8,8 @@ namespace AssertNet.Core.Tests.Assertions.Objects
     /// <summary>
     /// Test class for the <see cref="BooleanAssertion"/> class.
     /// </summary>
-    /// <seealso cref="ObjectAssertionTests{BooleanAssertion}" />
-    public class BooleanAssertionTests : ObjectAssertionTests<BooleanAssertion>
+    /// <seealso cref="ObjectAssertionTests{T1, T2}" />
+    public class BooleanAssertionTests : ObjectAssertionTests<BooleanAssertion, bool>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BooleanAssertionTests"/> class.

--- a/src/AssertNet.Core.Tests/Assertions/Objects/CollectionAssertionTests.cs
+++ b/src/AssertNet.Core.Tests/Assertions/Objects/CollectionAssertionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using AssertNet.Core.Assertions.Objects;
 using AssertNet.Core.Failures;
 using Moq;
@@ -9,7 +10,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
     /// <summary>
     /// Test class for the <see cref="CollectionAssertion"/> class.
     /// </summary>
-    public class CollectionAssertionTests : ObjectAssertionTests<CollectionAssertion>
+    public class CollectionAssertionTests : ObjectAssertionTests<CollectionAssertion<int>, IEnumerable<int>>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CollectionAssertionTests"/> class.
@@ -17,14 +18,14 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         public CollectionAssertionTests()
         {
             FailureHandler = new Mock<IFailureHandler>();
-            CollectionAssertion = new CollectionAssertion(FailureHandler.Object, new int[] { 1, 2, 3 });
+            CollectionAssertion = new CollectionAssertion<int>(FailureHandler.Object, new int[] { 1, 2, 3 });
             Assertion = CollectionAssertion;
         }
 
         /// <summary>
         /// Gets the assertion under test.
         /// </summary>
-        private CollectionAssertion CollectionAssertion { get; }
+        private CollectionAssertion<int> CollectionAssertion { get; }
 
         /// <summary>
         /// Checks that the assertion does not fail if the object is correctly contained.
@@ -72,7 +73,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void IsEmptyPassTest()
         {
-            new CollectionAssertion(FailureHandler.Object, Array.Empty<int>()).IsEmpty();
+            new CollectionAssertion<int>(FailureHandler.Object, Array.Empty<int>()).IsEmpty();
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Never());
         }
 
@@ -82,7 +83,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void IsEmptyFailTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 1 }).IsEmpty();
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 1 }).IsEmpty();
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.AtLeastOnce());
         }
 
@@ -92,7 +93,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void IsNotEmptyPassTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 1 }).IsNotEmpty();
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 1 }).IsNotEmpty();
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Never());
         }
 
@@ -102,7 +103,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void IsNotEmptyFailTest()
         {
-            new CollectionAssertion(FailureHandler.Object, Array.Empty<int>()).IsNotEmpty();
+            new CollectionAssertion<int>(FailureHandler.Object, Array.Empty<int>()).IsNotEmpty();
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.AtLeastOnce());
         }
 
@@ -112,7 +113,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void HasSizePassTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 1, 2, 3 }).HasSize(3);
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 1, 2, 3 }).HasSize(3);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Never());
         }
 
@@ -122,7 +123,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void HasSizeFailTest()
         {
-            new CollectionAssertion(FailureHandler.Object, Array.Empty<int>()).HasSize(3);
+            new CollectionAssertion<int>(FailureHandler.Object, Array.Empty<int>()).HasSize(3);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.AtLeastOnce());
         }
 
@@ -132,7 +133,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void HasAtLeastSizePassTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 1, 2, 3 }).HasAtLeastSize(2);
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 1, 2, 3 }).HasAtLeastSize(2);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Never());
         }
 
@@ -142,7 +143,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void HasAtLeastSizeFailTest()
         {
-            new CollectionAssertion(FailureHandler.Object, Array.Empty<int>()).HasAtLeastSize(1);
+            new CollectionAssertion<int>(FailureHandler.Object, Array.Empty<int>()).HasAtLeastSize(1);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.AtLeastOnce());
         }
 
@@ -152,7 +153,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void HasAtMostSizePassTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 5, 2 }).HasAtMostSize(4);
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 5, 2 }).HasAtMostSize(4);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Never());
         }
 
@@ -162,7 +163,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void HasAtMostSizeFailTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 1, 2, 3 }).HasAtMostSize(1);
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 1, 2, 3 }).HasAtMostSize(1);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.AtLeastOnce());
         }
 
@@ -172,7 +173,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void ContainsOnlyPassTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 2, 2, 1 }).ContainsOnly(1, 2);
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 2, 2, 1 }).ContainsOnly(1, 2);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Never());
         }
 
@@ -182,7 +183,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void ContainsOnlyFailTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 9, 3, 5 }).ContainsOnly(3, 4);
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 9, 3, 5 }).ContainsOnly(3, 4);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.AtLeastOnce());
         }
 
@@ -192,7 +193,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void ContainsExactlyPassTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 2, 9, 6 }).ContainsExactly(2, 9, 6);
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 2, 9, 6 }).ContainsExactly(2, 9, 6);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Never());
         }
 
@@ -202,7 +203,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void ContainsExactlyFailTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 5, 6, 7 }).ContainsExactly(5, 7, 6);
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 5, 6, 7 }).ContainsExactly(5, 7, 6);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.AtLeastOnce());
         }
 
@@ -212,7 +213,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void ContainsExactlyInAnyOrderPassTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 5, 6, 7 }).ContainsExactlyInAnyOrder(5, 7, 6);
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 5, 6, 7 }).ContainsExactlyInAnyOrder(5, 7, 6);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Never());
         }
 
@@ -222,7 +223,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void ContainsExactlyInAnyOrderWrongFailTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 5, 6, 7 }).ContainsExactlyInAnyOrder(5, 9, 7, 6);
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 5, 6, 7 }).ContainsExactlyInAnyOrder(5, 9, 7, 6);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.AtLeastOnce());
         }
 
@@ -232,7 +233,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void ContainsExactlyInAnyOrderTooManyFailTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 5, 6, 7 }).ContainsExactlyInAnyOrder(5, 6, 7, 7);
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 5, 6, 7 }).ContainsExactlyInAnyOrder(5, 6, 7, 7);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.AtLeastOnce());
         }
 
@@ -242,7 +243,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void ContainsExactlyInAnyOrderTooFewFailTest()
         {
-            new CollectionAssertion(FailureHandler.Object, new int[] { 5, 6, 7 }).ContainsExactlyInAnyOrder(5, 6);
+            new CollectionAssertion<int>(FailureHandler.Object, new int[] { 5, 6, 7 }).ContainsExactlyInAnyOrder(5, 6);
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.AtLeastOnce());
         }
     }

--- a/src/AssertNet.Core.Tests/Assertions/Objects/DoubleAssertionTests.cs
+++ b/src/AssertNet.Core.Tests/Assertions/Objects/DoubleAssertionTests.cs
@@ -9,8 +9,8 @@ namespace AssertNet.Core.Tests.Assertions.Objects
     /// <summary>
     /// Test class for the <see cref="DoubleAssertion"/> class.
     /// </summary>
-    /// <seealso cref="ObjectAssertionTests{DoubleAssertion}" />
-    public class DoubleAssertionTests : ObjectAssertionTests<DoubleAssertion>
+    /// <seealso cref="ObjectAssertionTests{TAssert, TTarget}" />
+    public class DoubleAssertionTests : ObjectAssertionTests<DoubleAssertion, double>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DoubleAssertionTests"/> class.

--- a/src/AssertNet.Core.Tests/Assertions/Objects/ObjectAssertionTests.cs
+++ b/src/AssertNet.Core.Tests/Assertions/Objects/ObjectAssertionTests.cs
@@ -6,11 +6,12 @@ using Xunit;
 namespace AssertNet.Core.Tests.Assertions.Objects
 {
     /// <summary>
-    /// Test class for the <see cref="ObjectAssertion{T}"/> class.
+    /// Test class for the <see cref="ObjectAssertion{TAssert, TTarget}"/> class.
     /// </summary>
-    /// <typeparam name="T">Type of the assertion.</typeparam>
-    public abstract class ObjectAssertionTests<T>
-        where T : ObjectAssertion<T>
+    /// <typeparam name="T1">Type of the assertion.</typeparam>
+    /// <typeparam name="T2">Type of the object under test.</typeparam>
+    public abstract class ObjectAssertionTests<T1, T2>
+        where T1 : ObjectAssertion<T1, T2>
     {
         /// <summary>
         /// Gets or sets the assertion under test.
@@ -18,7 +19,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         /// <value>
         /// The assertion under test.
         /// </value>
-        protected ObjectAssertion<T> Assertion { get; set; }
+        protected ObjectAssertion<T1, T2> Assertion { get; set; }
 
         /// <summary>
         /// Gets or sets the failure handler.

--- a/src/AssertNet.Core.Tests/Assertions/Objects/SingleAssertionTests.cs
+++ b/src/AssertNet.Core.Tests/Assertions/Objects/SingleAssertionTests.cs
@@ -6,9 +6,9 @@ using Xunit;
 namespace AssertNet.Core.Tests.Assertions.Objects
 {
     /// <summary>
-    /// Test class for the <see cref="SingleAssertion"/> class.
+    /// Test class for the <see cref="SingleAssertion{TTarget}"/> class.
     /// </summary>
-    public class SingleAssertionTests : ObjectAssertionTests<SingleAssertion>
+    public class SingleAssertionTests : ObjectAssertionTests<SingleAssertion<object>, object>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SingleAssertionTests"/> class.
@@ -16,7 +16,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         public SingleAssertionTests()
         {
             FailureHandler = new Mock<IFailureHandler>();
-            Assertion = new SingleAssertion(FailureHandler.Object, "bery43566435fgdtfg");
+            Assertion = new SingleAssertion<object>(FailureHandler.Object, "bery43566435fgdtfg");
         }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void IsNotNullFailTest()
         {
-            Assertion = new SingleAssertion(FailureHandler.Object, null);
+            Assertion = new SingleAssertion<object>(FailureHandler.Object, null);
             Assertion.IsNotNull();
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Once());
         }
@@ -36,7 +36,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void IsNullPassTest()
         {
-            Assertion = new SingleAssertion(FailureHandler.Object, null);
+            Assertion = new SingleAssertion<object>(FailureHandler.Object, null);
             Assertion.IsNull();
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Never());
         }

--- a/src/AssertNet.Core.Tests/Assertions/Objects/SingleAssertionTests.cs
+++ b/src/AssertNet.Core.Tests/Assertions/Objects/SingleAssertionTests.cs
@@ -6,9 +6,9 @@ using Xunit;
 namespace AssertNet.Core.Tests.Assertions.Objects
 {
     /// <summary>
-    /// Test class for the <see cref="SingleAssertion{TTarget}"/> class.
+    /// Test class for the <see cref="SingleAssertion"/> class.
     /// </summary>
-    public class SingleAssertionTests : ObjectAssertionTests<SingleAssertion<object>, object>
+    public class SingleAssertionTests : ObjectAssertionTests<SingleAssertion, object>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SingleAssertionTests"/> class.
@@ -16,7 +16,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         public SingleAssertionTests()
         {
             FailureHandler = new Mock<IFailureHandler>();
-            Assertion = new SingleAssertion<object>(FailureHandler.Object, "bery43566435fgdtfg");
+            Assertion = new SingleAssertion(FailureHandler.Object, "bery43566435fgdtfg");
         }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void IsNotNullFailTest()
         {
-            Assertion = new SingleAssertion<object>(FailureHandler.Object, null);
+            Assertion = new SingleAssertion(FailureHandler.Object, null);
             Assertion.IsNotNull();
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Once());
         }
@@ -36,7 +36,7 @@ namespace AssertNet.Core.Tests.Assertions.Objects
         [Fact]
         public void IsNullPassTest()
         {
-            Assertion = new SingleAssertion<object>(FailureHandler.Object, null);
+            Assertion = new SingleAssertion(FailureHandler.Object, null);
             Assertion.IsNull();
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Never());
         }

--- a/src/AssertNet.Core.Tests/Assertions/Objects/StringAssertionTests.cs
+++ b/src/AssertNet.Core.Tests/Assertions/Objects/StringAssertionTests.cs
@@ -8,8 +8,8 @@ namespace AssertNet.Core.Tests.Assertions.Objects
     /// <summary>
     /// Test class for the <see cref="StringAssertion"/> class.
     /// </summary>
-    /// <seealso cref="ObjectAssertionTests{StringAssertion}" />
-    public class StringAssertionTests : ObjectAssertionTests<StringAssertion>
+    /// <seealso cref="ObjectAssertionTests{TAssert, TTarget}" />
+    public class StringAssertionTests : ObjectAssertionTests<StringAssertion, string>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="StringAssertionTests"/> class.

--- a/src/AssertNet.Core.Tests/Assertions/Void/ExceptionAssertionTests.cs
+++ b/src/AssertNet.Core.Tests/Assertions/Void/ExceptionAssertionTests.cs
@@ -10,7 +10,7 @@ namespace AssertNet.Core.Tests.Assertions.Void
     /// <summary>
     /// Test class for the <see cref="ExceptionAssertion"/> class.
     /// </summary>
-    public class ExceptionAssertionTests : ObjectAssertionTests<ExceptionAssertion>
+    public class ExceptionAssertionTests : ObjectAssertionTests<ExceptionAssertion, Exception>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ExceptionAssertionTests"/> class.
@@ -30,7 +30,7 @@ namespace AssertNet.Core.Tests.Assertions.Void
             Exception e = new Mock<Exception>().Object;
             ExceptionAssertion assertion = new ExceptionAssertion(FailureHandler.Object, e);
             Assert.Same(FailureHandler.Object, assertion.FailureHandler);
-            Assert.Same(e, assertion.Exception);
+            Assert.Same(e, assertion.Target);
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace AssertNet.Core.Tests.Assertions.Void
                 FailureHandler.Object,
                 new Exception(string.Empty, inner)).WithInnerException();
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Never());
-            Assert.Same(inner, assertion.Exception);
+            Assert.Same(inner, assertion.Target);
         }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace AssertNet.Core.Tests.Assertions.Void
                 FailureHandler.Object,
                 new Exception(string.Empty, inner)).WithInnerException<ArgumentException>();
             FailureHandler.Verify(x => x.Fail(It.IsAny<string>()), Times.Never());
-            Assert.Same(inner, assertion.Exception);
+            Assert.Same(inner, assertion.Target);
         }
 
         /// <summary>

--- a/src/AssertNet.Core/Assertions/Objects/BooleanAssertion.cs
+++ b/src/AssertNet.Core/Assertions/Objects/BooleanAssertion.cs
@@ -1,13 +1,12 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using AssertNet.Core.Failures;
+﻿using AssertNet.Core.Failures;
 
 namespace AssertNet.Core.Assertions.Objects
 {
     /// <summary>
     /// Class representing assertions made on boolean items.
     /// </summary>
-    /// <seealso cref="ObjectAssertion{BooleanAssertion}" />
-    public class BooleanAssertion : ObjectAssertion<BooleanAssertion>
+    /// <seealso cref="ObjectAssertion{TAssert, TTarget}" />
+    public class BooleanAssertion : ObjectAssertion<BooleanAssertion, bool>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BooleanAssertion"/> class.
@@ -20,21 +19,12 @@ namespace AssertNet.Core.Assertions.Objects
         }
 
         /// <summary>
-        /// Gets the boolean value under test.
-        /// </summary>
-        /// <value>
-        /// The boolean value under test.
-        /// </value>
-        [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1623:Property summary documentation must match accessors", Justification = "Does not indicate the state of the object.")]
-        public bool Value => (bool)Target;
-
-        /// <summary>
         /// Asserts that the boolean value is true.
         /// </summary>
         /// <returns>The current assertion.</returns>
         public BooleanAssertion IsTrue()
         {
-            if (Value == false)
+            if (Target == false)
             {
                 Fail(new FailureBuilder("IsTrue()")
                     .Append("Expecting", Target)
@@ -51,7 +41,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public BooleanAssertion IsFalse()
         {
-            if (Value == true)
+            if (Target == true)
             {
                 Fail(new FailureBuilder("IsFalse()")
                     .Append("Expecting", Target)

--- a/src/AssertNet.Core/Assertions/Objects/CollectionAssertion.cs
+++ b/src/AssertNet.Core/Assertions/Objects/CollectionAssertion.cs
@@ -8,38 +8,31 @@ namespace AssertNet.Core.Assertions.Objects
     /// <summary>
     /// Class representing assertions made on collection objects.
     /// </summary>
-    /// <seealso cref="ObjectAssertion{CollectionAssertion}" />
-    public class CollectionAssertion : ObjectAssertion<CollectionAssertion>
+    /// <typeparam name="TElement">Element type of the enumerable.</typeparam>
+    /// <seealso cref="ObjectAssertion{TAssert, TTarget}" />
+    public class CollectionAssertion<TElement> : ObjectAssertion<CollectionAssertion<TElement>, IEnumerable<TElement>>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="CollectionAssertion"/> class.
+        /// Initializes a new instance of the <see cref="CollectionAssertion{TElement}"/> class.
         /// </summary>
         /// <param name="failureHandler">The failure handler of the assertion.</param>
         /// <param name="target">The object which is under test.</param>
-        public CollectionAssertion(IFailureHandler failureHandler, IEnumerable target)
+        public CollectionAssertion(IFailureHandler failureHandler, IEnumerable<TElement> target)
             : base(failureHandler, target)
         {
         }
 
         /// <summary>
-        /// Gets the collection under test.
-        /// </summary>
-        /// <value>
-        /// The collection under test.
-        /// </value>
-        public IEnumerable<object> Collection => ((IEnumerable)Target).Cast<object>();
-
-        /// <summary>
         /// Checks if the enumerable is empty.
         /// </summary>
         /// <returns>The current assertion.</returns>
-        public CollectionAssertion IsEmpty()
+        public CollectionAssertion<TElement> IsEmpty()
         {
-            if (Collection.Any())
+            if (Target.Any())
             {
                 Fail(new FailureBuilder("IsEmpty()")
                     .Append("Expecting", Target)
-                    .AppendEnumerable("To be empty, but contains", Collection)
+                    .AppendEnumerable("To be empty, but contains", Target)
                     .Finish());
             }
 
@@ -50,9 +43,9 @@ namespace AssertNet.Core.Assertions.Objects
         /// Checks if the enumerable is not empty.
         /// </summary>
         /// <returns>The current assertion.</returns>
-        public CollectionAssertion IsNotEmpty()
+        public CollectionAssertion<TElement> IsNotEmpty()
         {
-            if (!Collection.Any())
+            if (!Target.Any())
             {
                 Fail(new FailureBuilder("IsNotEmpty()")
                     .Append("Expecting", Target)
@@ -68,15 +61,15 @@ namespace AssertNet.Core.Assertions.Objects
         /// </summary>
         /// <param name="size">The size the enumerable should have.</param>
         /// <returns>The current assertion.</returns>
-        public CollectionAssertion HasSize(int size)
+        public CollectionAssertion<TElement> HasSize(int size)
         {
-            int realSize = Collection.Count();
+            int realSize = Target.Count();
             if (realSize != size)
             {
                 Fail(new FailureBuilder("HasSize()")
                     .Append("Expecting", Target)
                     .Append("To have a size of", size)
-                    .Append("But has a size of", Collection.Count())
+                    .Append("But has a size of", realSize)
                     .Finish());
             }
 
@@ -88,15 +81,15 @@ namespace AssertNet.Core.Assertions.Objects
         /// </summary>
         /// <param name="size">The size the enumerable should have.</param>
         /// <returns>The current assertion.</returns>
-        public CollectionAssertion HasAtLeastSize(int size)
+        public CollectionAssertion<TElement> HasAtLeastSize(int size)
         {
-            int realSize = Collection.Count();
+            int realSize = Target.Count();
             if (realSize < size)
             {
                 Fail(new FailureBuilder("HasAtLeastSize()")
                     .Append("Expecting", Target)
                     .Append("To have at least a size of", size)
-                    .Append("But has a size of", Collection.Count())
+                    .Append("But has a size of", realSize)
                     .Finish());
             }
 
@@ -108,15 +101,15 @@ namespace AssertNet.Core.Assertions.Objects
         /// </summary>
         /// <param name="size">The size the enumerable should have.</param>
         /// <returns>The current assertion.</returns>
-        public CollectionAssertion HasAtMostSize(int size)
+        public CollectionAssertion<TElement> HasAtMostSize(int size)
         {
-            int realSize = Collection.Count();
+            int realSize = Target.Count();
             if (realSize > size)
             {
                 Fail(new FailureBuilder("HasAtMostSize()")
                     .Append("Expecting", Target)
                     .Append("To have at most a size of", size)
-                    .Append("But has a size of", Collection.Count())
+                    .Append("But has a size of", realSize)
                     .Finish());
             }
 
@@ -128,14 +121,14 @@ namespace AssertNet.Core.Assertions.Objects
         /// </summary>
         /// <param name="values">The values to check for.</param>
         /// <returns>The current assertion.</returns>
-        public CollectionAssertion Contains(params object[] values)
+        public CollectionAssertion<TElement> Contains(params TElement[] values)
         {
-            object[] difference = values.Except(Collection).ToArray();
+            TElement[] difference = values.Except(Target).ToArray();
 
             if (difference.Any())
             {
                 Fail(new FailureBuilder("Contains()")
-                    .AppendEnumerable("Expecting", Collection)
+                    .AppendEnumerable("Expecting", Target)
                     .AppendEnumerable("To contain", values)
                     .AppendEnumerable("But misses", difference)
                     .Finish());
@@ -149,14 +142,14 @@ namespace AssertNet.Core.Assertions.Objects
         /// </summary>
         /// <param name="values">The values to check for.</param>
         /// <returns>The current assertion.</returns>
-        public CollectionAssertion DoesNotContain(params object[] values)
+        public CollectionAssertion<TElement> DoesNotContain(params TElement[] values)
         {
-            object[] intersection = values.Intersect(Collection).ToArray();
+            TElement[] intersection = values.Intersect(Target).ToArray();
 
             if (intersection.Any())
             {
                 Fail(new FailureBuilder("DoesNotContain()")
-                    .AppendEnumerable("Expecting", Collection)
+                    .AppendEnumerable("Expecting", Target)
                     .AppendEnumerable("Not to contain", values)
                     .AppendEnumerable("But contains", intersection)
                     .Finish());
@@ -170,14 +163,14 @@ namespace AssertNet.Core.Assertions.Objects
         /// </summary>
         /// <param name="values">The values to check for.</param>
         /// <returns>The current assertion.</returns>
-        public CollectionAssertion ContainsOnly(params object[] values)
+        public CollectionAssertion<TElement> ContainsOnly(params TElement[] values)
         {
-            object[] difference = Collection.Distinct().Except(values).ToArray();
+            TElement[] difference = Target.Distinct().Except(values).ToArray();
 
             if (difference.Any())
             {
                 Fail(new FailureBuilder("ContainsOnly()")
-                    .AppendEnumerable("Expecting", Collection)
+                    .AppendEnumerable("Expecting", Target)
                     .AppendEnumerable("To only contain", values)
                     .AppendEnumerable("But also contains", difference)
                     .Finish());
@@ -191,12 +184,12 @@ namespace AssertNet.Core.Assertions.Objects
         /// </summary>
         /// <param name="values">The values to check for.</param>
         /// <returns>The current assertion.</returns>
-        public CollectionAssertion ContainsExactly(params object[] values)
+        public CollectionAssertion<TElement> ContainsExactly(params TElement[] values)
         {
-            if (!Collection.SequenceEqual(values))
+            if (!Target.SequenceEqual(values))
             {
                 Fail(new FailureBuilder("ContainsExactly()")
-                    .AppendEnumerable("Expecting", Collection)
+                    .AppendEnumerable("Expecting", Target)
                     .AppendEnumerable("To contain exactly", values)
                     .Finish());
             }
@@ -209,26 +202,26 @@ namespace AssertNet.Core.Assertions.Objects
         /// </summary>
         /// <param name="values">The values to check for.</param>
         /// <returns>The current assertion.</returns>
-        public CollectionAssertion ContainsExactlyInAnyOrder(params object[] values)
+        public CollectionAssertion<TElement> ContainsExactlyInAnyOrder(params TElement[] values)
         {
-            List<object> valuesList = values.ToList();
-            List<object> collectionList = Collection.ToList();
+            List<TElement> valuesList = values.ToList();
+            List<TElement> targetList = Target.ToList();
 
             FailureBuilder failureBuilder = new FailureBuilder("ContainsExactlyInAnyOrder()");
 
             for (int i = valuesList.Count - 1; i >= 0; --i)
             {
-                int index = collectionList.IndexOf(valuesList[i]);
+                int index = targetList.IndexOf(valuesList[i]);
                 if (index >= 0)
                 {
                     valuesList.RemoveAt(i);
-                    collectionList.RemoveAt(index);
+                    targetList.RemoveAt(index);
                 }
             }
 
-            if (valuesList.Any() || collectionList.Any())
+            if (valuesList.Any() || targetList.Any())
             {
-                failureBuilder.AppendEnumerable("Expecting", Collection);
+                failureBuilder.AppendEnumerable("Expecting", Target);
                 failureBuilder.AppendEnumerable("To contain exactly in any order", values);
 
                 if (valuesList.Any())
@@ -236,9 +229,9 @@ namespace AssertNet.Core.Assertions.Objects
                     failureBuilder.AppendEnumerable("But did not find", valuesList);
                 }
 
-                if (collectionList.Any())
+                if (targetList.Any())
                 {
-                    failureBuilder.AppendEnumerable("But found excess", collectionList);
+                    failureBuilder.AppendEnumerable("But found excess", targetList);
                 }
 
                 Fail(failureBuilder.Finish());

--- a/src/AssertNet.Core/Assertions/Objects/DoubleAssertion.cs
+++ b/src/AssertNet.Core/Assertions/Objects/DoubleAssertion.cs
@@ -6,8 +6,8 @@ namespace AssertNet.Core.Assertions.Objects
     /// <summary>
     /// Class representing assertions made about doubles (and other numeric values).
     /// </summary>
-    /// <seealso cref="ObjectAssertion{DoubleAssertion}" />
-    public class DoubleAssertion : ObjectAssertion<DoubleAssertion>
+    /// <seealso cref="ObjectAssertion{TAssert, TTarget}" />
+    public class DoubleAssertion : ObjectAssertion<DoubleAssertion, double>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DoubleAssertion"/> class.
@@ -20,21 +20,13 @@ namespace AssertNet.Core.Assertions.Objects
         }
 
         /// <summary>
-        /// Gets the double under test.
-        /// </summary>
-        /// <value>
-        /// The double under test.
-        /// </value>
-        public double Value => (double)Target;
-
-        /// <summary>
         /// Asserts if a double is greater than a certain value.
         /// </summary>
         /// <param name="other">Value which the double should be greater than.</param>
         /// <returns>The current assertion.</returns>
         public DoubleAssertion IsGreaterThan(double other)
         {
-            if (Value <= other)
+            if (Target <= other)
             {
                 Fail(new FailureBuilder("IsGreaterThan()")
                     .Append("Expecting", Target)
@@ -52,7 +44,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public DoubleAssertion IsGreaterThanOrEqual(double other)
         {
-            if (Value < other)
+            if (Target < other)
             {
                 Fail(new FailureBuilder("IsGreaterThanOrEqual()")
                     .Append("Expecting", Target)
@@ -70,7 +62,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public DoubleAssertion IsLesserThan(double other)
         {
-            if (Value >= other)
+            if (Target >= other)
             {
                 Fail(new FailureBuilder("IsLesserThan()")
                     .Append("Expecting", Target)
@@ -88,7 +80,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public DoubleAssertion IsLesserThanOrEqual(double other)
         {
-            if (Value > other)
+            if (Target > other)
             {
                 Fail(new FailureBuilder("IsLesserThanOrEqual()")
                     .Append("Expecting", Target)
@@ -105,7 +97,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public DoubleAssertion IsZero()
         {
-            if (Value != 0)
+            if (Target != 0)
             {
                 Fail(new FailureBuilder("IsZero()")
                     .Append("Expecting", Target)
@@ -122,7 +114,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public DoubleAssertion IsPositive()
         {
-            if (Value <= 0)
+            if (Target <= 0)
             {
                 Fail(new FailureBuilder("IsPositive()")
                     .Append("Expecting", Target)
@@ -139,7 +131,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public DoubleAssertion IsPositiveOrZero()
         {
-            if (Value < 0)
+            if (Target < 0)
             {
                 Fail(new FailureBuilder("IsPositiveOrZero()")
                     .Append("Expecting", Target)
@@ -156,7 +148,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public DoubleAssertion IsNegative()
         {
-            if (Value >= 0)
+            if (Target >= 0)
             {
                 Fail(new FailureBuilder("IsNegative()")
                     .Append("Expecting", Target)
@@ -173,7 +165,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public DoubleAssertion IsNegativeOrZero()
         {
-            if (Value > 0)
+            if (Target > 0)
             {
                 Fail(new FailureBuilder("IsNegativeOrZero()")
                     .Append("Expecting", Target)
@@ -198,7 +190,7 @@ namespace AssertNet.Core.Assertions.Objects
                 throw new ArgumentException($"Value for 'minimum' ({minimum}) should be lower than the value for 'maximum' ({maximum}).");
             }
 
-            if (Value < minimum || Value > maximum)
+            if (Target < minimum || Target > maximum)
             {
                 Fail(new FailureBuilder("IsInRange()")
                     .Append("Expecting", Target)
@@ -224,7 +216,7 @@ namespace AssertNet.Core.Assertions.Objects
                 throw new ArgumentException($"Value for 'minimum' ({minimum}) should be lower than the value for 'maximum' ({maximum}).");
             }
 
-            if (Value >= minimum && Value <= maximum)
+            if (Target >= minimum && Target <= maximum)
             {
                 Fail(new FailureBuilder("IsNotInRange()")
                     .Append("Expecting", Target)
@@ -251,7 +243,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public DoubleAssertion IsEqualTo(double other, double margin)
         {
-            if (Value < other - margin || Value > other + margin)
+            if (Target < other - margin || Target > other + margin)
             {
                 Fail(new FailureBuilder("IsEqualTo()")
                     .Append("Expecting", Target)
@@ -278,7 +270,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public DoubleAssertion IsNotEqualTo(double other, double margin)
         {
-            if (Value >= other - margin && Value <= other + margin)
+            if (Target >= other - margin && Target <= other + margin)
             {
                 Fail(new FailureBuilder("IsNotEqualTo()")
                     .Append("Expecting", Target)

--- a/src/AssertNet.Core/Assertions/Objects/ObjectAssertion.cs
+++ b/src/AssertNet.Core/Assertions/Objects/ObjectAssertion.cs
@@ -75,7 +75,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public TAssert IsSameAs(object other)
         {
-            if (!ReferenceEquals(Target, other))
+            if ((Target.GetType().IsValueType && !Target.Equals(other)) || (!Target.GetType().IsValueType && !ReferenceEquals(Target, other)))
             {
                 Fail(new FailureBuilder("IsSameAs()")
                     .Append("Expecting", Target)
@@ -93,7 +93,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public TAssert IsNotSameAs(object other)
         {
-            if (ReferenceEquals(Target, other))
+            if ((Target.GetType().IsValueType && Target.Equals(other)) || (!Target.GetType().IsValueType && ReferenceEquals(Target, other)))
             {
                 Fail(new FailureBuilder("IsNotSameAs()")
                     .Append("Expecting", Target)

--- a/src/AssertNet.Core/Assertions/Objects/ObjectAssertion.cs
+++ b/src/AssertNet.Core/Assertions/Objects/ObjectAssertion.cs
@@ -8,16 +8,17 @@ namespace AssertNet.Core.Assertions.Objects
     /// Abstract class representing assertions of objects.
     /// </summary>
     /// <typeparam name="TAssert">Derived type of the assertion.</typeparam>
+    /// <typeparam name="TTarget">Type of the object under test.</typeparam>
     /// <seealso cref="Assertion" />
-    public abstract class ObjectAssertion<TAssert> : Assertion
-        where TAssert : ObjectAssertion<TAssert>
+    public abstract class ObjectAssertion<TAssert, TTarget> : Assertion
+        where TAssert : ObjectAssertion<TAssert, TTarget>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ObjectAssertion{TAssert}"/> class.
+        /// Initializes a new instance of the <see cref="ObjectAssertion{TAssert, TTarget}"/> class.
         /// </summary>
         /// <param name="target">The object which is under test.</param>
         /// <param name="failureHandler">The failure handler of the assertion.</param>
-        public ObjectAssertion(IFailureHandler failureHandler, object target)
+        public ObjectAssertion(IFailureHandler failureHandler, TTarget target)
             : base(failureHandler)
         {
             Target = target;
@@ -29,7 +30,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <value>
         /// The object under test.
         /// </value>
-        public object Target { get; }
+        public TTarget Target { get; }
 
         /// <summary>
         /// Checks whether the object under test is equal to another object.

--- a/src/AssertNet.Core/Assertions/Objects/SingleAssertion.cs
+++ b/src/AssertNet.Core/Assertions/Objects/SingleAssertion.cs
@@ -5,16 +5,15 @@ namespace AssertNet.Core.Assertions.Objects
     /// <summary>
     /// Class representing assertions made on single objects.
     /// </summary>
-    /// <typeparam name="TTarget">Type of the object under test.</typeparam>
     /// <seealso cref="ObjectAssertion{TAssert, TTarget}" />
-    public class SingleAssertion<TTarget> : ObjectAssertion<SingleAssertion<TTarget>, TTarget>
+    public class SingleAssertion : ObjectAssertion<SingleAssertion, object>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SingleAssertion{TTarget}"/> class.
+        /// Initializes a new instance of the <see cref="SingleAssertion"/> class.
         /// </summary>
         /// <param name="failureHandler">The failure handler of the assertion.</param>
         /// <param name="target">The object which is under test.</param>
-        public SingleAssertion(IFailureHandler failureHandler, TTarget target)
+        public SingleAssertion(IFailureHandler failureHandler, object target)
             : base(failureHandler, target)
         {
         }

--- a/src/AssertNet.Core/Assertions/Objects/SingleAssertion.cs
+++ b/src/AssertNet.Core/Assertions/Objects/SingleAssertion.cs
@@ -5,15 +5,16 @@ namespace AssertNet.Core.Assertions.Objects
     /// <summary>
     /// Class representing assertions made on single objects.
     /// </summary>
-    /// <seealso cref="ObjectAssertion{SingleAssertion}" />
-    public class SingleAssertion : ObjectAssertion<SingleAssertion>
+    /// <typeparam name="TTarget">Type of the object under test.</typeparam>
+    /// <seealso cref="ObjectAssertion{TAssert, TTarget}" />
+    public class SingleAssertion<TTarget> : ObjectAssertion<SingleAssertion<TTarget>, TTarget>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SingleAssertion"/> class.
+        /// Initializes a new instance of the <see cref="SingleAssertion{TTarget}"/> class.
         /// </summary>
         /// <param name="failureHandler">The failure handler of the assertion.</param>
         /// <param name="target">The object which is under test.</param>
-        public SingleAssertion(IFailureHandler failureHandler, object target)
+        public SingleAssertion(IFailureHandler failureHandler, TTarget target)
             : base(failureHandler, target)
         {
         }

--- a/src/AssertNet.Core/Assertions/Objects/StringAssertion.cs
+++ b/src/AssertNet.Core/Assertions/Objects/StringAssertion.cs
@@ -6,8 +6,8 @@ namespace AssertNet.Core.Assertions.Objects
     /// <summary>
     /// Class representing assertions made about strings.
     /// </summary>
-    /// <seealso cref="ObjectAssertion{StringAssertion}" />
-    public class StringAssertion : ObjectAssertion<StringAssertion>
+    /// <seealso cref="ObjectAssertion{TAssert, TTarget}" />
+    public class StringAssertion : ObjectAssertion<StringAssertion, string>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="StringAssertion"/> class.
@@ -20,21 +20,13 @@ namespace AssertNet.Core.Assertions.Objects
         }
 
         /// <summary>
-        /// Gets the string under test.
-        /// </summary>
-        /// <value>
-        /// The string under test.
-        /// </value>
-        public string Value => (string)Target;
-
-        /// <summary>
         /// Asserts if a string contains a certain substring.
         /// </summary>
         /// <param name="substring">Substring which needs to be contained.</param>
         /// <returns>The current assertion.</returns>
         public StringAssertion Contains(string substring)
         {
-            if (!Value.Contains(substring))
+            if (!Target.Contains(substring))
             {
                 Fail(new FailureBuilder("Contains()")
                     .Append("Expecting", Target)
@@ -52,7 +44,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion DoesNotContain(string substring)
         {
-            if (Value.Contains(substring))
+            if (Target.Contains(substring))
             {
                 Fail(new FailureBuilder("DoesNotContain()")
                     .Append("Expecting", Target)
@@ -70,7 +62,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion ContainsIgnoringCase(string substring)
         {
-            if (!Value.ToUpperInvariant().Contains(substring.ToUpperInvariant()))
+            if (!Target.ToUpperInvariant().Contains(substring.ToUpperInvariant()))
             {
                 Fail(new FailureBuilder("ContainsIgnoringCase()")
                     .Append("Expecting", Target)
@@ -88,7 +80,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion DoesNotContainIgnoringCase(string substring)
         {
-            if (Value.ToUpperInvariant().Contains(substring.ToUpperInvariant()))
+            if (Target.ToUpperInvariant().Contains(substring.ToUpperInvariant()))
             {
                 Fail(new FailureBuilder("DoesNotContainIgnoringCase()")
                     .Append("Expecting", Target)
@@ -106,7 +98,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion StartsWith(string substring)
         {
-            if (!Value.StartsWith(substring, false, CultureInfo.InvariantCulture))
+            if (!Target.StartsWith(substring, false, CultureInfo.InvariantCulture))
             {
                 Fail(new FailureBuilder("StartsWith()")
                     .Append("Expecting", Target)
@@ -124,7 +116,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion DoesNotStartWith(string substring)
         {
-            if (Value.StartsWith(substring, false, CultureInfo.InvariantCulture))
+            if (Target.StartsWith(substring, false, CultureInfo.InvariantCulture))
             {
                 Fail(new FailureBuilder("DoesNotStartWith()")
                     .Append("Expecting", Target)
@@ -142,7 +134,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion StartsWithIgnoringCase(string substring)
         {
-            if (!Value.StartsWith(substring, true, CultureInfo.InvariantCulture))
+            if (!Target.StartsWith(substring, true, CultureInfo.InvariantCulture))
             {
                 Fail(new FailureBuilder("StartsWithIgnoringCase()")
                     .Append("Expecting", Target)
@@ -160,7 +152,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion DoesNotStartWithIgnoringCase(string substring)
         {
-            if (Value.StartsWith(substring, true, CultureInfo.InvariantCulture))
+            if (Target.StartsWith(substring, true, CultureInfo.InvariantCulture))
             {
                 Fail(new FailureBuilder("DoesNotStartWithIgnoringCase()")
                     .Append("Expecting", Target)
@@ -178,7 +170,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion EndsWith(string substring)
         {
-            if (!Value.EndsWith(substring, false, CultureInfo.InvariantCulture))
+            if (!Target.EndsWith(substring, false, CultureInfo.InvariantCulture))
             {
                 Fail(new FailureBuilder("EndsWith()")
                     .Append("Expecting", Target)
@@ -196,7 +188,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion DoesNotEndWith(string substring)
         {
-            if (Value.EndsWith(substring, false, CultureInfo.InvariantCulture))
+            if (Target.EndsWith(substring, false, CultureInfo.InvariantCulture))
             {
                 Fail(new FailureBuilder("DoesNotEndWith()")
                     .Append("Expecting", Target)
@@ -214,7 +206,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion EndsWithIgnoringCase(string substring)
         {
-            if (!Value.EndsWith(substring, true, CultureInfo.InvariantCulture))
+            if (!Target.EndsWith(substring, true, CultureInfo.InvariantCulture))
             {
                 Fail(new FailureBuilder("EndsWithIgnoringCase()")
                     .Append("Expecting", Target)
@@ -232,7 +224,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion DoesNotEndWithIgnoringCase(string substring)
         {
-            if (Value.EndsWith(substring, true, CultureInfo.InvariantCulture))
+            if (Target.EndsWith(substring, true, CultureInfo.InvariantCulture))
             {
                 Fail(new FailureBuilder("DoesNotEndWithIgnoringCase()")
                     .Append("Expecting", Target)
@@ -249,7 +241,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion IsEmpty()
         {
-            if (Value.Length > 0)
+            if (Target.Length > 0)
             {
                 Fail(new FailureBuilder("IsEmpty()")
                     .Append("Expecting", Target)
@@ -266,7 +258,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion IsNotEmpty()
         {
-            if (Value.Length <= 0)
+            if (Target.Length <= 0)
             {
                 Fail(new FailureBuilder("IsNotEmpty()")
                     .Append("Expecting", Target)
@@ -283,7 +275,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion IsNullOrEmpty()
         {
-            if (!string.IsNullOrEmpty(Value))
+            if (!string.IsNullOrEmpty(Target))
             {
                 Fail(new FailureBuilder("IsNullOrEmpty()")
                     .Append("Expecting", Target)
@@ -300,7 +292,7 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion IsNotNullOrEmpty()
         {
-            if (string.IsNullOrEmpty(Value))
+            if (string.IsNullOrEmpty(Target))
             {
                 Fail(new FailureBuilder("IsNotNullOrEmpty()")
                     .Append("Expecting", Target)
@@ -318,12 +310,12 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion HasSize(int size)
         {
-            if (Value.Length != size)
+            if (Target.Length != size)
             {
                 Fail(new FailureBuilder("HasSize()")
                     .Append("Expecting", Target)
                     .Append("To have a length of", size)
-                    .Append("But has a length of", Value.Length)
+                    .Append("But has a length of", Target.Length)
                     .Finish());
             }
 
@@ -337,12 +329,12 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion HasAtLeastSize(int size)
         {
-            if (Value.Length < size)
+            if (Target.Length < size)
             {
                 Fail(new FailureBuilder("HasAtLeastSize()")
                     .Append("Expecting", Target)
                     .Append("To have at least a length of", size)
-                    .Append("But has length of", Value.Length)
+                    .Append("But has length of", Target.Length)
                     .Finish());
             }
 
@@ -356,12 +348,12 @@ namespace AssertNet.Core.Assertions.Objects
         /// <returns>The current assertion.</returns>
         public StringAssertion HasAtMostSize(int size)
         {
-            if (Value.Length > size)
+            if (Target.Length > size)
             {
                 Fail(new FailureBuilder("HasAtMostSize()")
                     .Append("Expecting", Target)
                     .Append("To have at most a length of", size)
-                    .Append("But has length of", Value.Length)
+                    .Append("But has length of", Target.Length)
                     .Finish());
             }
 

--- a/src/AssertNet.Core/Assertions/Void/ExceptionAssertion.cs
+++ b/src/AssertNet.Core/Assertions/Void/ExceptionAssertion.cs
@@ -8,7 +8,7 @@ namespace AssertNet.Core.Assertions.Void
     /// Class representing assertions made on thrown exceptions.
     /// </summary>
     /// <seealso cref="Assertion" />
-    public class ExceptionAssertion : ObjectAssertion<ExceptionAssertion>
+    public class ExceptionAssertion : ObjectAssertion<ExceptionAssertion, Exception>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ExceptionAssertion"/> class.
@@ -18,16 +18,7 @@ namespace AssertNet.Core.Assertions.Void
         public ExceptionAssertion(IFailureHandler failureHandler, Exception exception)
             : base(failureHandler, exception)
         {
-            Exception = exception;
         }
-
-        /// <summary>
-        /// Gets the exception under test.
-        /// </summary>
-        /// <value>
-        /// The exception under test.
-        /// </value>
-        public Exception Exception { get; }
 
         /// <summary>
         /// Asserts that an exception has a certain message.
@@ -36,12 +27,12 @@ namespace AssertNet.Core.Assertions.Void
         /// <returns>The current assertion.</returns>
         public ExceptionAssertion WithMessage(string message)
         {
-            if (Exception.Message != message)
+            if (Target.Message != message)
             {
                 Fail(new FailureBuilder("WithMessage()")
                     .Append("Expecting", Target)
                     .Append("To have the message", message)
-                    .Append("But has the message", Exception.Message)
+                    .Append("But has the message", Target.Message)
                     .Finish());
             }
 
@@ -56,12 +47,12 @@ namespace AssertNet.Core.Assertions.Void
         /// <returns>The current assertion.</returns>
         public ExceptionAssertion WithMessageContaining(string message)
         {
-            if (!Exception.Message.Contains(message))
+            if (!Target.Message.Contains(message))
             {
                 Fail(new FailureBuilder("WithMessageContaining()")
                     .Append("Expecting", Target)
                     .Append("To have a message containing", message)
-                    .Append("But has the message", Exception.Message)
+                    .Append("But has the message", Target.Message)
                     .Finish());
             }
 
@@ -74,11 +65,11 @@ namespace AssertNet.Core.Assertions.Void
         /// <returns>The current assertion.</returns>
         public ExceptionAssertion WithNoInnerException()
         {
-            if (Exception.InnerException != null)
+            if (Target.InnerException != null)
             {
                 Fail(new FailureBuilder("WithMessageContaining()")
                     .Append("Expecting", Target)
-                    .Append("To not have an inner exception, but has", Exception.InnerException)
+                    .Append("To not have an inner exception, but has", Target.InnerException)
                     .Finish());
             }
 
@@ -91,9 +82,9 @@ namespace AssertNet.Core.Assertions.Void
         /// <returns>An exception assertion for the inner exception.</returns>
         public ExceptionAssertion WithInnerException()
         {
-            if (Exception.InnerException != null)
+            if (Target.InnerException != null)
             {
-                return new ExceptionAssertion(FailureHandler, Exception.InnerException);
+                return new ExceptionAssertion(FailureHandler, Target.InnerException);
             }
 
             Fail(new FailureBuilder("WithInnerException()")
@@ -111,7 +102,7 @@ namespace AssertNet.Core.Assertions.Void
         public ExceptionAssertion WithInnerException<T>()
             where T : Exception
         {
-            if (Exception.InnerException == null)
+            if (Target.InnerException == null)
             {
                 Fail(new FailureBuilder("WithInnerException()")
                     .Append("Expecting", Target)
@@ -119,17 +110,17 @@ namespace AssertNet.Core.Assertions.Void
                     .Finish());
                 return null;
             }
-            else if (!(Exception.InnerException is T))
+            else if (!(Target.InnerException is T))
             {
                 Fail(new FailureBuilder("WithInnerException()")
                     .Append("Expecting", Target)
                     .Append("To have an inner exception of type", typeof(T))
-                    .Append("But has an inner exception of type", Exception.InnerException.GetType())
+                    .Append("But has an inner exception of type", Target.InnerException.GetType())
                     .Finish());
                 return null;
             }
 
-            return new ExceptionAssertion(FailureHandler, Exception.InnerException);
+            return new ExceptionAssertion(FailureHandler, Target.InnerException);
         }
     }
 }

--- a/src/AssertNet.Core/Failures/FailureBuilder.cs
+++ b/src/AssertNet.Core/Failures/FailureBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -44,7 +43,7 @@ namespace AssertNet.Core.Failures
         /// <returns>The current <see cref="FailureBuilder"/> instance.</returns>
         public FailureBuilder AppendEnumerable<T>(string objectName, IEnumerable<T> enumerable)
         {
-            _builder.Append($"{Environment.NewLine}{objectName}:{Environment.NewLine}[{string.Join(", ", enumerable)}]");
+            _builder.Append($"{Environment.NewLine}{objectName}:{Environment.NewLine}[{string.Join(", ", enumerable.Select(StringOf))}]");
             return this;
         }
 
@@ -71,14 +70,6 @@ namespace AssertNet.Core.Failures
         /// <typeparam name="T">Type of the object.</typeparam>
         /// <param name="ob">The object to get the string version of.</param>
         /// <returns>"null" if the object is null. The value of .ToString() otherwise.</returns>
-        private static string StringOf<T>(T ob)
-        {
-            if (ob == null)
-            {
-                return "null";
-            }
-
-            return ob.ToString();
-        }
+        private static string StringOf<T>(T ob) => ob == null ? "null" : ob.ToString();
     }
 }

--- a/src/AssertNet.MSTest.Tests/AssertionsTests.cs
+++ b/src/AssertNet.MSTest.Tests/AssertionsTests.cs
@@ -77,7 +77,7 @@ namespace AssertNet.Nunit.Tests
         {
             Assertion assertion = AssertThat(Array.Empty<int>());
             Assert.IsNotNull(assertion);
-            Assert.IsInstanceOfType(assertion, typeof(CollectionAssertion));
+            Assert.IsInstanceOfType(assertion, typeof(CollectionAssertion<int>));
         }
 
         /// <summary>

--- a/src/AssertNet.MSTest/Assertions.cs
+++ b/src/AssertNet.MSTest/Assertions.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections;
+using System.Collections.Generic;
 using AssertNet.Core.Assertions.Objects;
 using AssertNet.Core.Assertions.Void;
 
@@ -63,11 +63,12 @@ namespace AssertNet.MSTest
         /// <summary>
         /// Makes an assertion about an enumerable.
         /// </summary>
+        /// <typeparam name="T">Type of the elements in the enumerable.</typeparam>
         /// <param name="enumerable">Enumerable under test.</param>
         /// <returns>Assertion about an enumerable.</returns>
-        public static CollectionAssertion AssertThat(IEnumerable enumerable)
+        public static CollectionAssertion<T> AssertThat<T>(IEnumerable<T> enumerable)
         {
-            return new CollectionAssertion(new MSTestFailureHandler(), enumerable);
+            return new CollectionAssertion<T>(new MSTestFailureHandler(), enumerable);
         }
 
         /// <summary>

--- a/src/AssertNet.NUnit.Tests/AssertionsTests.cs
+++ b/src/AssertNet.NUnit.Tests/AssertionsTests.cs
@@ -77,7 +77,7 @@ namespace AssertNet.Nunit.Tests
         {
             Assertion assertion = AssertThat(Array.Empty<int>());
             Assert.NotNull(assertion);
-            Assert.IsInstanceOf<CollectionAssertion>(assertion);
+            Assert.IsInstanceOf<CollectionAssertion<int>>(assertion);
         }
 
         /// <summary>

--- a/src/AssertNet.NUnit/Assertions.cs
+++ b/src/AssertNet.NUnit/Assertions.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections;
+using System.Collections.Generic;
 using AssertNet.Core.Assertions.Objects;
 using AssertNet.Core.Assertions.Void;
 
@@ -63,11 +63,12 @@ namespace AssertNet.NUnit
         /// <summary>
         /// Makes an assertion about an enumerable.
         /// </summary>
+        /// <typeparam name="T">Type of the elements in the enumerable.</typeparam>
         /// <param name="enumerable">Enumerable under test.</param>
         /// <returns>Assertion about an enumerable.</returns>
-        public static CollectionAssertion AssertThat(IEnumerable enumerable)
+        public static CollectionAssertion<T> AssertThat<T>(IEnumerable<T> enumerable)
         {
-            return new CollectionAssertion(new NUnitFailureHandler(), enumerable);
+            return new CollectionAssertion<T>(new NUnitFailureHandler(), enumerable);
         }
 
         /// <summary>

--- a/src/AssertNet.Xunit.Tests/AssertionsTests.cs
+++ b/src/AssertNet.Xunit.Tests/AssertionsTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using AssertNet.Core.Assertions;
 using AssertNet.Core.Assertions.Objects;
 using AssertNet.Core.Assertions.Void;
@@ -74,7 +73,7 @@ namespace AssertNet.Xunit.Tests
         [Fact]
         public static void CollectionAssertionTest()
         {
-            Assertion assertion = AssertThat(new List<int>());
+            Assertion assertion = AssertThat(Array.Empty<int>());
             Assert.NotNull(assertion);
             Assert.IsType<CollectionAssertion<int>>(assertion);
         }

--- a/src/AssertNet.Xunit.Tests/AssertionsTests.cs
+++ b/src/AssertNet.Xunit.Tests/AssertionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using AssertNet.Core.Assertions;
 using AssertNet.Core.Assertions.Objects;
 using AssertNet.Core.Assertions.Void;
@@ -73,9 +74,9 @@ namespace AssertNet.Xunit.Tests
         [Fact]
         public static void CollectionAssertionTest()
         {
-            Assertion assertion = AssertThat(Array.Empty<int>());
+            Assertion assertion = AssertThat(new List<int>());
             Assert.NotNull(assertion);
-            Assert.IsType<CollectionAssertion>(assertion);
+            Assert.IsType<CollectionAssertion<int>>(assertion);
         }
 
         /// <summary>

--- a/src/AssertNet.Xunit/Assertions.cs
+++ b/src/AssertNet.Xunit/Assertions.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections;
+using System.Collections.Generic;
 using AssertNet.Core.Assertions.Objects;
 using AssertNet.Core.Assertions.Void;
 
@@ -63,11 +63,12 @@ namespace AssertNet.Xunit
         /// <summary>
         /// Makes an assertion about an enumerable.
         /// </summary>
+        /// <typeparam name="T">Type of the elements in the enumerable.</typeparam>
         /// <param name="enumerable">Enumerable under test.</param>
         /// <returns>Assertion about an enumerable.</returns>
-        public static CollectionAssertion AssertThat(IEnumerable enumerable)
+        public static CollectionAssertion<T> AssertThat<T>(IEnumerable<T> enumerable)
         {
-            return new CollectionAssertion(new XunitFailureHandler(), enumerable);
+            return new CollectionAssertion<T>(new XunitFailureHandler(), enumerable);
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves #3

#### Changes:
- Added another generic type to `ObjectAssertion`.
- Fixed bug where `.ThrowsException()` would always pass.