### PR TITLE
Update NUnit tests

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,9 +17,9 @@
     <PackageVersion Include="Moq" Version="4.12.0" />
     <PackageVersion Include="Moq.Analyzers" Version="0.2.0" />
     <PackageVersion Include="MSTest" Version="3.6.1" />
-    <PackageVersion Include="NUnit" Version="3.14.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="3.9.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageVersion Include="NUnit" Version="4.3.2" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.6.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="Qowaiv.Analyzers.CSharp" Version="2.0.3" />
     <PackageVersion Include="Qowaiv.Diagnostics.Contracts" Version="2.0.3" />

--- a/src/Tests/AssertNet.Tests.Nunit/AssertNet.Tests.Nunit.csproj
+++ b/src/Tests/AssertNet.Tests.Nunit/AssertNet.Tests.Nunit.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="../../nunit.props"/>
+  <Import Project="../../nunit.props" />
 
 </Project>

--- a/src/Tests/AssertNet.Tests.Nunit/FailureHandlers/FailureHandlerFactoryTests.cs
+++ b/src/Tests/AssertNet.Tests.Nunit/FailureHandlers/FailureHandlerFactoryTests.cs
@@ -14,6 +14,6 @@ public static class FailureHandlerFactoryTests
     [Test]
     public static void FactoryTest()
     {
-        Assert.IsInstanceOf<NunitFailureHandler>(FailureHandlerFactory.Create());
+        Assert.That(FailureHandlerFactory.Create(), Is.InstanceOf<NunitFailureHandler>());
     }
 }

--- a/src/Tests/AssertNet.Tests.Nunit/FailureHandlers/NunitFailureHandlerTests.cs
+++ b/src/Tests/AssertNet.Tests.Nunit/FailureHandlers/NunitFailureHandlerTests.cs
@@ -24,7 +24,7 @@ public class NunitFailureHandlerTests
     [Test]
     public void AvailableTest()
     {
-        Assert.True(handler.IsAvailable());
+        Assert.That(handler.IsAvailable(), Is.True);
     }
 
     /// <summary>
@@ -35,6 +35,7 @@ public class NunitFailureHandlerTests
     {
         string msg = "54363tr3f4";
         Exception e = Assert.Throws<AssertionException>(() => handler.Fail(msg));
-        Assert.AreEqual(msg, e.Message);
+
+        Assert.That(e.Message, Is.EqualTo(msg));
     }
 }

--- a/src/nunit.props
+++ b/src/nunit.props
@@ -3,7 +3,7 @@
   <Import Project="tests.props" />
 
   <ItemGroup Label="Analyzers">
-    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="NUnit.Analyzers" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="Dependencies">


### PR DESCRIPTION
NUnit released a new (breaking) version some time ago, dropping there own classic `Assert.AreEqual` API. Updated the project to use that new syntax, and using the latest versions of some packages.