### PR TITLE
Use extensions to have best coverage on assertions

### DIFF
--- a/src/Libraries/AssertNet.Core/AssertNet.Core.csproj
+++ b/src/Libraries/AssertNet.Core/AssertNet.Core.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <PackageId>AssertNet.Core</PackageId>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net9.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/src/Libraries/AssertNet.Core/AssertionTypes/Assertion_T.cs
+++ b/src/Libraries/AssertNet.Core/AssertionTypes/Assertion_T.cs
@@ -1,0 +1,14 @@
+namespace AssertNet.Core.AssertionTypes;
+
+public abstract class Assertion<TSubject> : Assertion
+{
+    protected Assertion(TSubject subject, IFailureHandler failureHandler) : base(failureHandler)
+    {
+        Subject = subject;
+    }
+
+    /// <summary>The subject under test.</summary>
+    public TSubject Subject { get; }
+
+    public void Fails(string message) => Fail(message);
+}

--- a/src/Libraries/AssertNet.Core/AssertionTypes/NumericAssertions.cs
+++ b/src/Libraries/AssertNet.Core/AssertionTypes/NumericAssertions.cs
@@ -1,0 +1,34 @@
+#if NET8_0_OR_GREATER
+
+using System.Numerics;
+
+namespace AssertNet.Core.AssertionTypes;
+
+public static class NumericAssertions
+{
+    public static void IsFinate<TNumber>(this Assertion<TNumber> assertion, string? message = null) where TNumber : struct, INumber<TNumber>
+    {
+        if (!TNumber.IsFinite(assertion.Subject))
+        {
+            assertion.Fails(new FailureBuilder("IsZero()")
+                 .Append(message)
+                 .Append("Expecting", assertion.Subject)
+                 .Append("To be finate")
+                 .Finish());
+        }
+    }
+
+    public static void IsZero<TNumber>(this Assertion<TNumber> assertion, string? message = null) where TNumber : struct, INumber<TNumber>
+    {
+        if (!TNumber.IsZero(assertion.Subject))
+        {
+            assertion.Fails(new FailureBuilder("IsZero()")
+                .Append(message)
+                .Append("Expecting", assertion.Subject)
+                .Append("To be equal to", TNumber.Zero)
+                .Finish());
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Resolves #
To reduce the number of Assertion classes needed, it can be useful to have assertion methods as extenions on the type of the subject of the Assertion(Builder).