### PR TITLE
Decorate all (potential) pure functions

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -53,6 +53,7 @@ dotnet_diagnostic.CA2254.severity = warning     # Template should be a static ex
 dotnet_diagnostic.CA1860.severity = none        #  Prefer comparing 'Length' to 0 rather than using 'Any()'
 
 dotnet_diagnostic.QW0001.severity = none        # Use a testable Time Provider
+dotnet_diagnostic.QW0003.severity = warning     # Decorate pure functions
 dotnet_diagnostic.QW0005.severity = none        # Seal class or make explicity inheritable
 
 dotnet_diagnostic.S100.severity  = none         # Properties should be named in PascalCase

--- a/src/Libraries/AssertNet/AssertionTypes/Assertion_T_T.cs
+++ b/src/Libraries/AssertNet/AssertionTypes/Assertion_T_T.cs
@@ -30,18 +30,22 @@ public class Assertion<TAssert, TSubject> : IAssertion<TSubject>
     public IFailureHandler FailureHandler { get; }
 
     /// <inheritdoc cref="ObjectAssertions.IsNotInstanceOf{TAssert}(TAssert, Type, string?)" />
+    [Assertion]
     public TAssert IsNotInstanceOf<T>(string? message = null)
         => (TAssert)ObjectAssertions.IsNotInstanceOf<T>(this, message);
 
     /// <inheritdoc cref="ObjectAssertions.IsNotExactlyInstanceOf{TAssert}(TAssert, Type, string?)" />
+    [Assertion]
     public TAssert IsNotExactlyInstanceOf<T>(string? message = null)
         => (TAssert)ObjectAssertions.IsNotExactlyInstanceOf<T>(this, message);
 
     /// <inheritdoc cref="ObjectAssertions.Satisfies{TSubject}(IAssertion{TSubject}, Func{TSubject, bool}, string?)" />
+    [Assertion]
     public TAssert Satisfies(Func<TSubject, bool> condition, string? message = null)
         => (TAssert)ObjectAssertions.Satisfies(this, condition, message);
 
     /// <inheritdoc cref="ObjectAssertions.DoesNotSatisfy{TSubject}(IAssertion{TSubject}, Func{TSubject, bool}, string?)" />
+    [Assertion]
     public TAssert DoesNotSatisfy(Func<TSubject, bool> condition, string? message = null)
         => (TAssert)ObjectAssertions.DoesNotSatisfy(this, condition, message);
 }

--- a/src/Libraries/AssertNet/AssertionTypes/Extensions/ActionAssertions.cs
+++ b/src/Libraries/AssertNet/AssertionTypes/Extensions/ActionAssertions.cs
@@ -11,6 +11,7 @@ public static class ActionAssertions
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotThrowException<TAssert>(this TAssert assertion, string? message = null)
         where TAssert : IAssertion<Action>
     {
@@ -37,6 +38,7 @@ public static class ActionAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="T">Type of the exception which may not be thrown.</typeparam>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static IAssertion<Action> DoesNotThrowException<T>(this IAssertion<Action> assertion, string? message = null)
         where T : Exception
     {
@@ -66,6 +68,7 @@ public static class ActionAssertions
     /// <param name="t">Type of the exception which may not be thrown.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotThrowException<TAssert>(this TAssert assertion, Type t, string? message = null)
         where TAssert : IAssertion<Action>
     {
@@ -95,6 +98,7 @@ public static class ActionAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="T">Type of the exception which may not be thrown.</typeparam>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static IAssertion<Action> DoesNotThrowExactlyException<T>(this IAssertion<Action> assertion, string? message = null)
         where T : Exception
     {
@@ -124,6 +128,7 @@ public static class ActionAssertions
     /// <param name="t">Type of the exception which may not be thrown.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotThrowExactlyException<TAssert>(this TAssert assertion, Type t, string? message = null)
         where TAssert : IAssertion<Action>
     {
@@ -152,6 +157,7 @@ public static class ActionAssertions
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>An exception assertion for the thrown exception.</returns>
+    [Assertion]
     public static IAssertion<Exception> ThrowsException(this IAssertion<Action> assertion, string? message = null)
     {
         try
@@ -178,6 +184,7 @@ public static class ActionAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="T">Exception type to expect.</typeparam>
     /// <returns>An exception assertion for the thrown exception.</returns>
+    [Assertion]
     public static IAssertion<T> ThrowsException<T>(this IAssertion<Action> assertion, string? message = null)
         where T : Exception
     {
@@ -215,6 +222,7 @@ public static class ActionAssertions
     /// <param name="t">Exception type to expect.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>An exception assertion for the thrown exception.</returns>
+    [Assertion]
     public static IAssertion<Exception> ThrowsException(this IAssertion<Action> assertion, Type t, string? message = null)
     {
         try
@@ -254,6 +262,7 @@ public static class ActionAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="T">Exception type to expect.</typeparam>
     /// <returns>An exception assertion for the thrown exception.</returns>
+    [Assertion]
     public static IAssertion<T> ThrowsExactlyException<T>(this IAssertion<Action> assertion, string? message = null)
         where T : Exception
     {
@@ -293,6 +302,7 @@ public static class ActionAssertions
     /// <param name="t">Exception type to expect.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>An exception assertion for the thrown exception.</returns>
+    [Assertion]
     public static IAssertion<Exception> ThrowsExactlyException(this IAssertion<Action> assertion, Type t, string? message = null)
     {
         try

--- a/src/Libraries/AssertNet/AssertionTypes/Extensions/BooleanAssertions.cs
+++ b/src/Libraries/AssertNet/AssertionTypes/Extensions/BooleanAssertions.cs
@@ -15,6 +15,7 @@ public static class BooleanAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert IsTrue<TAssert>(this TAssert assertion, string? message = null)
         where TAssert : IAssertion<bool>
     {
@@ -37,6 +38,7 @@ public static class BooleanAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert IsFalse<TAssert>(this TAssert assertion, string? message = null)
         where TAssert : IAssertion<bool>
     {

--- a/src/Libraries/AssertNet/AssertionTypes/Extensions/EnumerableAssertions.cs
+++ b/src/Libraries/AssertNet/AssertionTypes/Extensions/EnumerableAssertions.cs
@@ -5,7 +5,6 @@ namespace AssertNet;
 /// <summary>
 /// Class representing assertions made on collection objects.
 /// </summary>
-/// <typeparam name="TElement">Element type of the enumerable.</typeparam>
 /// <seealso cref="Assertion{TAssert, TTarget}" />
 public static class EnumerableAssertions
 {
@@ -14,6 +13,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsEmpty<TAssert>(this TAssert assertion, string? message = null)
         where TAssert : IAssertion<IEnumerable>
     {
@@ -42,6 +42,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsNotEmpty<TAssert>(this TAssert assertion, string? message = null)
         where TAssert : IAssertion<IEnumerable>
     {
@@ -71,6 +72,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsNullOrEmpty<TAssert>(this TAssert assertion, string? message = null)
         where TAssert : IAssertion<IEnumerable?>
     {
@@ -91,6 +93,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsNotNullOrEmpty<TAssert>(this TAssert assertion, string? message = null)
         where TAssert : IAssertion<IEnumerable?>
     {
@@ -112,6 +115,7 @@ public static class EnumerableAssertions
     /// <param name="size">The size the enumerable should have.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert HasSize<TAssert>(this TAssert assertion, int size, string? message = null)
         where TAssert : IAssertion<IEnumerable>
     {
@@ -146,6 +150,7 @@ public static class EnumerableAssertions
     /// <param name="size">The size the enumerable should have.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert HasAtLeastSize<TAssert>(this TAssert assertion, int size, string? message = null)
         where TAssert : IAssertion<IEnumerable>
     {
@@ -180,6 +185,7 @@ public static class EnumerableAssertions
     /// <param name="size">The size the enumerable should have.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert HasAtMostSize<TAssert>(this TAssert assertion, int size, string? message = null)
         where TAssert : IAssertion<IEnumerable>
     {
@@ -213,6 +219,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="values">The values to check for.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert Contains<TAssert, TElement>(this TAssert assertion, params IEnumerable<TElement> values)
         where TAssert : IAssertion<IEnumerable<TElement>>
         => assertion.Contains(values, message: null);
@@ -223,6 +230,7 @@ public static class EnumerableAssertions
     /// <param name="values">The values to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert Contains<TAssert, TElement>(this TAssert assertion, IEnumerable<TElement> values, string? message = null)
         where TAssert : IAssertion<IEnumerable<TElement>>
     {
@@ -257,6 +265,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="values">The values to check for.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotContain<TAssert, TElement>(this TAssert assertion, params IEnumerable<TElement> values)
         where TAssert : IAssertion<IEnumerable<TElement>>
         => assertion.DoesNotContain(values, message: null);
@@ -267,6 +276,7 @@ public static class EnumerableAssertions
     /// <param name="values">The values to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotContain<TAssert, TElement>(this TAssert assertion, IEnumerable<TElement> values, string? message = null)
         where TAssert : IAssertion<IEnumerable<TElement>>
     {
@@ -295,6 +305,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="values">The values to check for.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert ContainsOnly<TAssert, TElement>(this TAssert assertion, params IEnumerable<TElement> values)
         where TAssert : IAssertion<IEnumerable<TElement>>
         => assertion.ContainsOnly(values, message: null);
@@ -305,6 +316,7 @@ public static class EnumerableAssertions
     /// <param name="values">The values to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert ContainsOnly<TAssert, TElement>(this TAssert assertion, IEnumerable<TElement> values, string? message = null)
         where TAssert : IAssertion<IEnumerable<TElement>>
     {
@@ -338,6 +350,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="values">The values to check for.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotContainOnly<TAssert, TElement>(this TAssert assertion, params IEnumerable<TElement> values)
         where TAssert : IAssertion<IEnumerable<TElement>>
         => assertion.DoesNotContainOnly(values, message: null);
@@ -348,6 +361,7 @@ public static class EnumerableAssertions
     /// <param name="values">The values to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotContainOnly<TAssert, TElement>(this TAssert assertion, IEnumerable<TElement> values, string? message = null)
         where TAssert : IAssertion<IEnumerable<TElement>>
     {
@@ -375,6 +389,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="values">The values to check for.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert ContainsExactly<TAssert, TElement>(this TAssert assertion, params IEnumerable<TElement> values)
         where TAssert : IAssertion<IEnumerable<TElement>>
         => assertion.ContainsExactly(values, message: null);
@@ -385,6 +400,7 @@ public static class EnumerableAssertions
     /// <param name="values">The values to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert ContainsExactly<TAssert, TElement>(this TAssert assertion, IEnumerable<TElement> values, string? message = null)
         where TAssert : IAssertion<IEnumerable<TElement>>
     {
@@ -415,6 +431,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="values">The values to check for.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotContainExactly<TAssert, TElement>(this TAssert assertion, params IEnumerable<TElement> values)
         where TAssert : IAssertion<IEnumerable<TElement>>
         => assertion.DoesNotContainExactly(values, message: null);
@@ -425,6 +442,7 @@ public static class EnumerableAssertions
     /// <param name="values">The values to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotContainExactly<TAssert, TElement>(this TAssert assertion, IEnumerable<TElement> values, string? message = null)
         where TAssert : IAssertion<IEnumerable<TElement>>
     {
@@ -449,6 +467,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="values">The values to check for.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert ContainsExactlyInAnyOrder<TAssert, TElement>(this TAssert assertion, params IEnumerable<TElement> values)
         where TAssert : IAssertion<IEnumerable<TElement>>
         => assertion.ContainsExactlyInAnyOrder(values, message: null);
@@ -459,6 +478,7 @@ public static class EnumerableAssertions
     /// <param name="values">The values to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert ContainsExactlyInAnyOrder<TAssert, TElement>(this TAssert assertion, IEnumerable<TElement> values, string? message = null)
         where TAssert : IAssertion<IEnumerable<TElement>>
     {
@@ -515,6 +535,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="values">The values to check for.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotContainExactlyInAnyOrder<TAssert, TElement>(this TAssert assertion, params IEnumerable<TElement> values)
         where TAssert : IAssertion<IEnumerable<TElement>>
         => assertion.DoesNotContainExactlyInAnyOrder(values, message: null);
@@ -525,6 +546,7 @@ public static class EnumerableAssertions
     /// <param name="values">The values to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotContainExactlyInAnyOrder<TAssert, TElement>(this TAssert assertion, IEnumerable<TElement> values, string? message = null)
         where TAssert : IAssertion<IEnumerable<TElement>>
     {
@@ -563,6 +585,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="values">The values to check for.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert ContainsSequence<TAssert, TElement>(this TAssert assertion, params IEnumerable<TElement> values)
         where TAssert : IAssertion<IEnumerable<TElement>>
         => assertion.ContainsSequence(values, message: null);
@@ -573,6 +596,7 @@ public static class EnumerableAssertions
     /// <param name="values">The values to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert ContainsSequence<TAssert, TElement>(this TAssert assertion, IEnumerable<TElement> values, string? message = null)
         where TAssert : IAssertion<IEnumerable<TElement>>
     {
@@ -615,6 +639,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="values">The values to check for.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotContainSequence<TAssert, TElement>(this TAssert assertion, params IEnumerable<TElement> values)
         where TAssert : IAssertion<IEnumerable<TElement>>
         => assertion.DoesNotContainSequence(values, message: null);
@@ -625,6 +650,7 @@ public static class EnumerableAssertions
     /// <param name="values">The values to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotContainSequence<TAssert, TElement>(this TAssert assertion, IEnumerable<TElement> values, string? message = null)
         where TAssert : IAssertion<IEnumerable<TElement>>
     {
@@ -660,6 +686,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="values">The values to check for.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert ContainsInterleavedSequence<TAssert, TElement>(this TAssert assertion, params IEnumerable<TElement> values)
         where TAssert : IAssertion<IEnumerable<TElement>>
         => assertion.ContainsInterleavedSequence(values, message: null);
@@ -670,6 +697,7 @@ public static class EnumerableAssertions
     /// <param name="values">The values to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert ContainsInterleavedSequence<TAssert, TElement>(this TAssert assertion, IEnumerable<TElement> values, string? message = null)
         where TAssert : IAssertion<IEnumerable<TElement>>
     {
@@ -713,6 +741,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="values">The values to check for.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotContainInterleavedSequence<TAssert, TElement>(this TAssert assertion, params IEnumerable<TElement> values)
         where TAssert : IAssertion<IEnumerable<TElement>>
         => assertion.DoesNotContainInterleavedSequence(values, message: null);
@@ -723,6 +752,7 @@ public static class EnumerableAssertions
     /// <param name="values">The values to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotContainInterleavedSequence<TAssert, TElement>(this TAssert assertion, IEnumerable<TElement> values, string? message = null)
         where TAssert : IAssertion<IEnumerable<TElement>>
     {
@@ -763,6 +793,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert ContainsNull<TAssert>(this TAssert assertion, string? message = null)
         where TAssert : IAssertion<IEnumerable>
     {
@@ -796,6 +827,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotContainNull<TAssert>(this TAssert assertion, string? message = null)
         where TAssert : IAssertion<IEnumerable>
     {
@@ -824,6 +856,7 @@ public static class EnumerableAssertions
     /// <param name="condition">The condition which needs to hold for all elements.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static IAssertion<IEnumerable<TElement>> AllSatisfy<TElement>(this IAssertion<IEnumerable<TElement>> assertion, Func<TElement, bool> condition, string? message = null)
     {
         if (assertion.Subject is null)
@@ -858,6 +891,7 @@ public static class EnumerableAssertions
     /// <param name="condition">The condition which needs to hold for some element.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static IAssertion<IEnumerable<TElement>> SomeSatisfy<TElement>(this IAssertion<IEnumerable<TElement>> assertion, Func<TElement, bool> condition, string? message = null)
     {
         if (assertion.Subject is null)
@@ -891,6 +925,7 @@ public static class EnumerableAssertions
     /// <param name="condition">The condition which may not hold for each element.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static IAssertion<IEnumerable<TElement>> NoneSatisfy<TElement>(this IAssertion<IEnumerable<TElement>> assertion, Func<TElement, bool> condition, string? message = null)
     {
         if (assertion.Subject is null)
@@ -918,6 +953,7 @@ public static class EnumerableAssertions
     /// </summary>
     /// <param name="condition">The condition to filter on.</param>
     /// <returns>A new assertion for a filtered version of the target enumerable.</returns>
+    [Assertion]
     public static IAssertion<IEnumerable<TElement>> Where<TElement>(this IAssertion<IEnumerable<TElement>> assertion, Func<TElement, bool> condition)
         => new Assertion<IEnumerable<TElement>>(assertion.FailureHandler, assertion.Subject.Where(condition));
 
@@ -928,6 +964,7 @@ public static class EnumerableAssertions
     /// <typeparam name="TOut">The output type of the projection.</typeparam>
     /// <param name="selector">The selector for the projection.</param>
     /// <returns>A new assertion for a projected version of the target enumerable.</returns>
+    [Assertion]
     public static IAssertion<IEnumerable<TOut>> Select<TIn, TOut>(this IAssertion<IEnumerable<TIn>> assertion, Func<TIn, TOut> selector)
         => new Assertion<IEnumerable<TOut>>(assertion.FailureHandler, assertion.Subject.Select(selector));
 
@@ -935,6 +972,7 @@ public static class EnumerableAssertions
     /// Creates a new assertion for a filtered version of the target enumerable.
     /// </summary>
     /// <returns>A new assertion for a filtered version of the target enumerable.</returns>
+    [Assertion]
     public static IAssertion<IEnumerable<TElement>> OfType<TElement>(this IAssertion<IEnumerable> assertion)
         => new Assertion<IEnumerable<TElement>>(assertion.FailureHandler, assertion.Subject.OfType<TElement>());
 }

--- a/src/Libraries/AssertNet/AssertionTypes/Extensions/ExceptionAssertion.cs
+++ b/src/Libraries/AssertNet/AssertionTypes/Extensions/ExceptionAssertion.cs
@@ -1,5 +1,4 @@
 using AssertNet.AssertionTypes;
-using System.Reflection;
 
 namespace AssertNet;
 
@@ -14,6 +13,7 @@ public static class ExceptionAssertions
     /// <param name="message">The message which the exception should have.</param>
     /// <param name="customMessage">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert WithMessage<TAssert>(this TAssert assertion, string message, string? customMessage = null)
         where TAssert : IAssertion<Exception>
     {
@@ -46,6 +46,7 @@ public static class ExceptionAssertions
     /// <param name="message">Part of the message which the exception should have.</param>
     /// <param name="customMessage">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert WithMessageContaining<TAssert>(this TAssert assertion, string message, string? customMessage = null)
         where TAssert : IAssertion<Exception>
     {
@@ -76,6 +77,7 @@ public static class ExceptionAssertions
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert WithNoInnerException<TAssert>(this TAssert assertion, string? message = null)
         where TAssert : IAssertion<Exception>
     {
@@ -106,6 +108,7 @@ public static class ExceptionAssertions
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>An exception assertion for the inner exception.</returns>
+    [Assertion]
     public static IAssertion<Exception> WithInnerException(this IAssertion<Exception> assertion, string? message = null)
     {
         if (assertion.Subject is null)
@@ -134,6 +137,7 @@ public static class ExceptionAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="T">Type of the inner exception.</typeparam>
     /// <returns>An exception assertion for the inner exception.</returns>
+    [Assertion]
     public static IAssertion<TInnerException> WithInnerException<TInnerException>(this IAssertion<Exception> assertion, string? message = null)
         where TInnerException : Exception
     {

--- a/src/Libraries/AssertNet/AssertionTypes/Extensions/ObjectAssertions.cs
+++ b/src/Libraries/AssertNet/AssertionTypes/Extensions/ObjectAssertions.cs
@@ -13,6 +13,7 @@ public static class ObjectAssertions
     /// <param name="other">The other object to compare with.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsEqualTo<TAssert>(this TAssert assertion, object? other, string? message = null)
         where TAssert : IAssertion
     {
@@ -34,6 +35,7 @@ public static class ObjectAssertions
     /// <param name="other">The other object to compare with.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsNotEqualTo<TAssert>(this TAssert assertion, object? other, string? message = null)
         where TAssert : IAssertion
     {
@@ -55,6 +57,7 @@ public static class ObjectAssertions
     /// <param name="other">The other object to compare with.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsEquivalentTo<TAssert>(this TAssert assertion, object? other, string? message = null)
         where TAssert : IAssertion
     {
@@ -76,6 +79,7 @@ public static class ObjectAssertions
     /// <param name="other">The other object to compare with.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsNotEquivalentTo<TAssert>(this TAssert assertion, object? other, string? message = null)
         where TAssert : IAssertion
     {
@@ -97,6 +101,7 @@ public static class ObjectAssertions
     /// <param name="other">The other to compare with.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsSameAs<TAssert>(this TAssert assertion, object? other, string? message = null)
         where TAssert : IAssertion
     {
@@ -121,6 +126,7 @@ public static class ObjectAssertions
     /// <param name="other">The other to compare with.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsNotSameAs<TAssert>(this TAssert assertion, object? other, string? message = null)
         where TAssert : IAssertion
     {
@@ -144,6 +150,7 @@ public static class ObjectAssertions
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsNull<TAssert>(this TAssert assertion, string? message = null)
         where TAssert : IAssertion
     {
@@ -164,6 +171,7 @@ public static class ObjectAssertions
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsNotNull<TAssert>(this TAssert assertion, string? message = null)
         where TAssert : IAssertion
     {
@@ -185,6 +193,7 @@ public static class ObjectAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="T">Type to check for.</typeparam>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static IAssertion<T> IsInstanceOf<T>(this IAssertion assertion, string? message = null)
     {
         var t = typeof(T);
@@ -221,6 +230,7 @@ public static class ObjectAssertions
     /// <param name="t">Type to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsInstanceOf<TAssert>(this TAssert assertion, Type t, string? message = null)
         where TAssert : IAssertion
     {
@@ -252,6 +262,7 @@ public static class ObjectAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="T">Type to check for.</typeparam>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static IAssertion IsNotInstanceOf<T>(this IAssertion assertion, string? message = null)
         => assertion.IsNotInstanceOf(typeof(T), message);
 
@@ -261,6 +272,7 @@ public static class ObjectAssertions
     /// <param name="t">Type to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsNotInstanceOf<TAssert>(this TAssert assertion, Type t, string? message = null)
         where TAssert : IAssertion
     {
@@ -282,6 +294,7 @@ public static class ObjectAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="T">Type to check for.</typeparam>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static IAssertion<T> IsExactlyInstanceOf<T>(this IAssertion assertion, string? message = null)
     {
         var t = typeof(T);
@@ -318,6 +331,7 @@ public static class ObjectAssertions
     /// <param name="t">Type to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsExactlyInstanceOf<TAssert>(this TAssert assertion, Type t, string? message = null)
         where TAssert : IAssertion
     {
@@ -349,6 +363,7 @@ public static class ObjectAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="T">Type to check for.</typeparam>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static IAssertion IsNotExactlyInstanceOf<T>(this IAssertion assertion, string? message = null)
         => assertion.IsNotExactlyInstanceOf(typeof(T), message);
 
@@ -358,6 +373,7 @@ public static class ObjectAssertions
     /// <param name="t">Type to check for.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsNotExactlyInstanceOf<TAssert>(this TAssert assertion, Type t, string? message = null)
         where TAssert : IAssertion
     {
@@ -379,6 +395,7 @@ public static class ObjectAssertions
     /// <param name="enumerable">The enumerable to check in.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsIn<TAssert>(this TAssert assertion, IEnumerable enumerable, string? message = null)
         where TAssert : IAssertion
     {
@@ -400,6 +417,7 @@ public static class ObjectAssertions
     /// <param name="enumerable">The enumerable to check in.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert IsNotIn<TAssert>(this TAssert assertion, IEnumerable enumerable, string? message = null)
         where TAssert : IAssertion
     {
@@ -421,6 +439,7 @@ public static class ObjectAssertions
     /// <param name="condition">The condition which needs to hold for the object.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static IAssertion<TSubject> Satisfies<TSubject>(this IAssertion<TSubject> assertion, Func<TSubject, bool> condition, string? message = null)
     {
         if (!condition.Invoke(assertion.Subject!))
@@ -441,6 +460,7 @@ public static class ObjectAssertions
     /// <param name="condition">The condition which may not hold for the object.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static IAssertion<TSubject> DoesNotSatisfy<TSubject>(this IAssertion<TSubject> assertion, Func<TSubject, bool> condition, string? message = null)
     {
         if (condition.Invoke(assertion.Subject!))
@@ -461,6 +481,7 @@ public static class ObjectAssertions
     /// <param name="hashCode">The expected hash code of the object.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert HasHashCode<TAssert>(this TAssert assertion, int hashCode, string? message = null)
         where TAssert : IAssertion
     {
@@ -492,6 +513,7 @@ public static class ObjectAssertions
     /// <param name="hashCode">The forbidden hash code of the object.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotHaveHashCode<TAssert>(this TAssert assertion, int hashCode, string? message = null)
         where TAssert : IAssertion
     {
@@ -513,6 +535,7 @@ public static class ObjectAssertions
     /// <param name="other">The other object which should have the same hash code.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert HasSameHashCodeAs<TAssert>(this TAssert assertion, object? other, string? message = null)
         where TAssert : IAssertion
     {
@@ -556,6 +579,7 @@ public static class ObjectAssertions
     /// <param name="other">The other object which may not have the same hash code.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert DoesNotHaveSameHashCodeAs<TAssert>(this TAssert assertion, object? other, string? message = null)
         where TAssert : IAssertion
     {
@@ -585,6 +609,7 @@ public static class ObjectAssertions
     /// <param name="str">The expected ToString() result.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public static TAssert ToStringYields<TAssert>(this TAssert assertion, string? str, string? message = null)
         where TAssert : IAssertion
     {

--- a/src/Libraries/AssertNet/AssertionTypes/Extensions/StringAssertions.cs
+++ b/src/Libraries/AssertNet/AssertionTypes/Extensions/StringAssertions.cs
@@ -16,6 +16,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert IsEqualToIgnoringCase<TAssert>(this TAssert assertion, string? other, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -39,6 +40,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert IsNotEqualToIgnoringCase<TAssert>(this TAssert assertion, string other, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -62,6 +64,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert Contains<TAssert>(this TAssert assertion, string substring, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -85,6 +88,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert DoesNotContain<TAssert>(this TAssert assertion, string substring, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -108,6 +112,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert ContainsIgnoringCase<TAssert>(this TAssert assertion, string substring, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -131,6 +136,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert DoesNotContainIgnoringCase<TAssert>(this TAssert assertion, string substring, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -154,6 +160,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert ContainsPattern<TAssert>(this TAssert assertion, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -177,6 +184,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert DoesNotContainPattern<TAssert>(this TAssert assertion, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -200,6 +208,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert StartsWith<TAssert>(this TAssert assertion, string substring, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -223,6 +232,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert DoesNotStartWith<TAssert>(this TAssert assertion, string substring, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -246,6 +256,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert StartsWithIgnoringCase<TAssert>(this TAssert assertion, string substring, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -269,6 +280,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert DoesNotStartWithIgnoringCase<TAssert>(this TAssert assertion, string substring, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -292,6 +304,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert EndsWith<TAssert>(this TAssert assertion, string substring, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -315,6 +328,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert DoesNotEndWith<TAssert>(this TAssert assertion, string substring, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -338,6 +352,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert EndsWithIgnoringCase<TAssert>(this TAssert assertion, string substring, string? message = null)
         where TAssert : IAssertion<string>
     {
@@ -361,6 +376,7 @@ public static class StringAssertions
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <typeparam name="TAssert">The type of assertion.</typeparam>
     /// <returns>The updated assertion chain.</returns>
+    [Assertion]
     public static TAssert DoesNotEndWithIgnoringCase<TAssert>(this TAssert assertion, string substring, string? message = null)
         where TAssert : IAssertion<string>
     {

--- a/src/Libraries/AssertNet/AssertionTypes/Objects/DoubleAssertion.cs
+++ b/src/Libraries/AssertNet/AssertionTypes/Objects/DoubleAssertion.cs
@@ -22,6 +22,7 @@ public class DoubleAssertion : Assertion<DoubleAssertion, double>
     /// <param name="other">Value which the double should be greater than.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public DoubleAssertion IsGreaterThan(double other, string? message = null)
     {
         if (Subject <= other)
@@ -42,6 +43,7 @@ public class DoubleAssertion : Assertion<DoubleAssertion, double>
     /// <param name="other">Value which the double should be greater than or equal to.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public DoubleAssertion IsGreaterThanOrEqualTo(double other, string? message = null)
     {
         if (Subject < other)
@@ -62,6 +64,7 @@ public class DoubleAssertion : Assertion<DoubleAssertion, double>
     /// <param name="other">Value which the double should be lesser than.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public DoubleAssertion IsLesserThan(double other, string? message = null)
     {
         if (Subject >= other)
@@ -82,6 +85,7 @@ public class DoubleAssertion : Assertion<DoubleAssertion, double>
     /// <param name="other">Value which the double should be lesser than or equal to.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public DoubleAssertion IsLesserThanOrEqualTo(double other, string? message = null)
     {
         if (Subject > other)
@@ -101,6 +105,7 @@ public class DoubleAssertion : Assertion<DoubleAssertion, double>
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public DoubleAssertion IsZero(string? message = null)
     {
 #pragma warning disable S1244 // Intentionally comparing to exactly zero.
@@ -122,6 +127,7 @@ public class DoubleAssertion : Assertion<DoubleAssertion, double>
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public DoubleAssertion IsPositive(string? message = null)
     {
         if (Subject <= 0)
@@ -141,6 +147,7 @@ public class DoubleAssertion : Assertion<DoubleAssertion, double>
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public DoubleAssertion IsPositiveOrZero(string? message = null)
     {
         if (Subject < 0)
@@ -160,6 +167,7 @@ public class DoubleAssertion : Assertion<DoubleAssertion, double>
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public DoubleAssertion IsNegative(string? message = null)
     {
         if (Subject >= 0)
@@ -179,6 +187,7 @@ public class DoubleAssertion : Assertion<DoubleAssertion, double>
     /// </summary>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public DoubleAssertion IsNegativeOrZero(string? message = null)
     {
         if (Subject > 0)
@@ -201,6 +210,7 @@ public class DoubleAssertion : Assertion<DoubleAssertion, double>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
     /// <exception cref="ArgumentException">Thrown if the maximum is larger or equal to the minimum.</exception>
+    [Assertion]
     public DoubleAssertion IsInRange(double minimum, double maximum, string? message = null)
     {
         if (maximum <= minimum)
@@ -229,6 +239,7 @@ public class DoubleAssertion : Assertion<DoubleAssertion, double>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
     /// <exception cref="ArgumentException">Thrown if the maximum is larger or equal to the minimum.</exception>
+    [Assertion]
     public DoubleAssertion IsNotInRange(double minimum, double maximum, string? message = null)
     {
         if (maximum <= minimum)
@@ -256,6 +267,7 @@ public class DoubleAssertion : Assertion<DoubleAssertion, double>
     /// <param name="margin">The margin to still identify another double as equal.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public DoubleAssertion IsEqualTo(double other, double margin, string? message = null)
     {
         if (Subject < other - margin || Subject > other + margin)
@@ -278,6 +290,7 @@ public class DoubleAssertion : Assertion<DoubleAssertion, double>
     /// <param name="margin">The margin to still identify another double as equal.</param>
     /// <param name="message">Custom message for the assertion failure.</param>
     /// <returns>The current assertion.</returns>
+    [Assertion]
     public DoubleAssertion IsNotEqualTo(double other, double margin, string? message = null)
     {
         if (Subject >= other - margin && Subject <= other + margin)

--- a/src/Libraries/AssertNet/Assertions.cs
+++ b/src/Libraries/AssertNet/Assertions.cs
@@ -1,5 +1,4 @@
 using AssertNet.AssertionTypes;
-using AssertNet.AssertionTypes.Objects;
 
 namespace AssertNet;
 
@@ -13,6 +12,7 @@ public static class Assertions
     /// </summary>
     /// <param name="value">Numeric value under test.</param>
     /// <returns>Assertion about a numeric value.</returns>
+    [Pure]
     public static DoubleAssertion That(this AssertionBuilder _, double value) => new(FailureHandlerFactory.Create(), value);
 
     /// <summary>
@@ -21,6 +21,7 @@ public static class Assertions
     /// <param name="value">Object under test.</param>
     /// <returns>Assertion about an object.</returns>
     [OverloadResolutionPriority(-100)]
+    [Pure]
     public static Assertion<T> That<T>(this AssertionBuilder _, T value) => new(FailureHandlerFactory.Create(), value);
 
     /// <summary>

--- a/src/Libraries/AssertNet/Diagnostics/AssertionAttribute.cs
+++ b/src/Libraries/AssertNet/Diagnostics/AssertionAttribute.cs
@@ -1,0 +1,5 @@
+namespace AssertNet.Diagnostics;
+
+/// <summary>Indicates that the method checks an assertion.</summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+internal sealed class AssertionAttribute(string? justification = null) : ImpureAttribute(justification) { }

--- a/src/Libraries/AssertNet/Diagnostics/AssertionAttribute.cs
+++ b/src/Libraries/AssertNet/Diagnostics/AssertionAttribute.cs
@@ -2,4 +2,4 @@ namespace AssertNet.Diagnostics;
 
 /// <summary>Indicates that the method checks an assertion.</summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
-internal sealed class AssertionAttribute(string? justification = null) : ImpureAttribute(justification) { }
+internal sealed class AssertionAttribute() : ImpureAttribute(null) { }

--- a/src/Libraries/AssertNet/FailureHandlers/ExceptionFailureHandler.cs
+++ b/src/Libraries/AssertNet/FailureHandlers/ExceptionFailureHandler.cs
@@ -27,6 +27,7 @@ public abstract class ExceptionFailureHandler : IFailureHandler
         }
     }
 
+    [Pure]
     private static Func<string, Exception> GenerateCreationFunction(Type? type)
     {
         if (type is null)
@@ -62,6 +63,7 @@ public abstract class ExceptionFailureHandler : IFailureHandler
         => throw createException(message);
 
     /// <inheritdoc/>
+    [Pure]
     public bool IsAvailable()
         => createException != defaultCreateException;
 

--- a/src/Libraries/AssertNet/FailureHandlers/FailureHandlerFactory.cs
+++ b/src/Libraries/AssertNet/FailureHandlers/FailureHandlerFactory.cs
@@ -11,9 +11,11 @@ public static class FailureHandlerFactory
     /// Creates a <see cref="IFailureHandler"/> instance based on the avaiable testing frameworks.
     /// </summary>
     /// <returns>A new <see cref="IFailureHandler"/> instance.</returns>
+    [Pure]
     public static IFailureHandler Create()
         => lazyHandler.Value;
 
+    [Pure]
     private static IFailureHandler CreateInternal()
     {
         var types = typeof(FailureHandlerFactory).Assembly.GetTypes()

--- a/src/Libraries/AssertNet/FailureHandlers/FallbackFailureHandler.cs
+++ b/src/Libraries/AssertNet/FailureHandlers/FallbackFailureHandler.cs
@@ -12,6 +12,7 @@ public class FallbackFailureHandler : IFailureHandler
         => throw new AssertionFailedException(message);
 
     /// <inheritdoc/>
+    [Pure]
     public bool IsAvailable()
         => true;
 }

--- a/src/Libraries/AssertNet/Failures/FailureBuilder.cs
+++ b/src/Libraries/AssertNet/Failures/FailureBuilder.cs
@@ -23,6 +23,7 @@ public class FailureBuilder
     /// <param name="objectName">Name of the object.</param>
     /// <param name="part">The object.</param>
     /// <returns>The current <see cref="FailureBuilder"/> instance.</returns>
+    [FluentSyntax]
     public FailureBuilder Append<T>(string objectName, T? part)
     {
         _builder.Append($"{Environment.NewLine}{objectName}:{Environment.NewLine}{StringOf(part)}");
@@ -34,6 +35,7 @@ public class FailureBuilder
     /// </summary>
     /// <param name="line">The line.</param>
     /// <returns>The current <see cref="FailureBuilder"/> instance.</returns>
+    [FluentSyntax]
     public FailureBuilder Append(string? line)
     {
         if (line != null)
@@ -51,6 +53,7 @@ public class FailureBuilder
     /// <param name="objectName">Name of the enumerable.</param>
     /// <param name="enumerable">The enumerable.</param>
     /// <returns>The current <see cref="FailureBuilder"/> instance.</returns>
+    [FluentSyntax]
     public FailureBuilder AppendEnumerable<T>(string objectName, IEnumerable<T> enumerable)
     {
         _builder.Append($"{Environment.NewLine}{objectName}:{Environment.NewLine}[{string.Join(", ", enumerable.Select(StringOf))}]");
@@ -58,6 +61,7 @@ public class FailureBuilder
     }
 
     /// <inheritdoc cref="AppendEnumerable{T}(string, IEnumerable{T})" />
+    [FluentSyntax]
     public FailureBuilder AppendEnumerable(string objectName, IEnumerable enumerable)
         => AppendEnumerable(objectName, enumerable.AsGeneric());
 
@@ -65,6 +69,7 @@ public class FailureBuilder
     /// Finishes the FailureBuilder instance.
     /// </summary>
     /// <returns>The assertion error message created.</returns>
+    [Pure]
     public string Finish() => _builder.ToString();
 
     /// <summary>
@@ -73,5 +78,6 @@ public class FailureBuilder
     /// <typeparam name="T">Type of the object.</typeparam>
     /// <param name="ob">The object to get the string version of.</param>
     /// <returns>"null" if the object is null. The value of .ToString() otherwise.</returns>
+    [Pure]
     private static string StringOf<T>(T? ob) => ob is null ? "null" : ob.ToString();
 }

--- a/src/Libraries/AssertNet/Failures/IFailureHandler.cs
+++ b/src/Libraries/AssertNet/Failures/IFailureHandler.cs
@@ -9,6 +9,7 @@ public interface IFailureHandler
     /// Determines whether this instance is available.
     /// </summary>
     /// <returns><c>true</c> if this instance is available; otherwise, <c>false</c>.</returns>
+    [Pure]
     bool IsAvailable();
 
     /// <summary>

--- a/src/Libraries/AssertNet/Helpers/EqualityHelper.cs
+++ b/src/Libraries/AssertNet/Helpers/EqualityHelper.cs
@@ -10,6 +10,7 @@ namespace AssertNet.Helpers;
 public static class EqualityHelper
 {
     /// <inheritdoc cref="object.Equals(object, object)" />
+    [Pure]
     public static new bool Equals(object? objA, object? objB)
         => (objA, objB) switch
         {
@@ -205,6 +206,7 @@ public static class EqualityHelper
         }
     }
 
+    [Pure]
     private static bool EqualsDecimal(float f, decimal d)
     {
         const float decimalMin = (float)decimal.MinValue;
@@ -218,6 +220,7 @@ public static class EqualityHelper
         return (decimal)f == d;
     }
 
+    [Pure]
     private static bool EqualsDecimal(double f, decimal d)
     {
         const double decimalMin = (double)decimal.MinValue;

--- a/src/Libraries/AssertNet/Helpers/EquivalencyHelper.cs
+++ b/src/Libraries/AssertNet/Helpers/EquivalencyHelper.cs
@@ -11,9 +11,11 @@ public static class EquivalencyHelper
     /// <param name="that">The object to check for.</param>
     /// <param name="other">The object to check with.</param>
     /// <returns>True if internally equal, false otherwise.</returns>
+    [Pure]
     public static bool AreEquivalent(object? that, object? other)
-        => AreEquivalent(that, other, new Dictionary<ReferenceWrapper, HashSet<ReferenceWrapper>>());
+        => AreEquivalent(that, other, []);
 
+    [Pure]
     private static bool AreEquivalent(this object? that, object? other, Dictionary<ReferenceWrapper, HashSet<ReferenceWrapper>> comparisons)
     {
         if (that is null || other is null)
@@ -52,6 +54,7 @@ public static class EquivalencyHelper
         return ObjectEquals(that, other, comparisons);
     }
 
+    [Pure]
     private static bool ArrayEquals(Array that, Array other, Dictionary<ReferenceWrapper, HashSet<ReferenceWrapper>> comparisons)
     {
         if (that.Length != other.Length)
@@ -77,6 +80,7 @@ public static class EquivalencyHelper
         return true;
     }
 
+    [Pure]
     private static bool ObjectEquals(object that, object other, Dictionary<ReferenceWrapper, HashSet<ReferenceWrapper>> comparisons)
     {
         Type type = that.GetType();
@@ -93,6 +97,7 @@ public static class EquivalencyHelper
         return true;
     }
 
+    [Pure]
     private static bool EqualsForType(object that, object other, Type type, Dictionary<ReferenceWrapper, HashSet<ReferenceWrapper>> comparisons)
     {
 #pragma warning disable S3011 // Intentionally accessing private fields.

--- a/src/Libraries/AssertNet/Helpers/ReferenceWrapper.cs
+++ b/src/Libraries/AssertNet/Helpers/ReferenceWrapper.cs
@@ -18,10 +18,12 @@ internal struct ReferenceWrapper : IEquatable<ReferenceWrapper>
     internal object Target { get; }
 
     /// <inheritdoc/>
+    [Pure]
     public bool Equals(ReferenceWrapper other)
         => ReferenceEquals(Target, other.Target);
 
     /// <inheritdoc/>
+    [Pure]
     public override bool Equals(object obj)
     {
         if (obj is ReferenceWrapper other)
@@ -33,6 +35,7 @@ internal struct ReferenceWrapper : IEquatable<ReferenceWrapper>
     }
 
     /// <inheritdoc/>
+    [Pure]
     public override int GetHashCode()
         => RuntimeHelpers.GetHashCode(Target);
 }

--- a/src/Libraries/AssertNet/Internal/EnumerableExtensions.cs
+++ b/src/Libraries/AssertNet/Internal/EnumerableExtensions.cs
@@ -2,6 +2,7 @@ namespace AssertNet.Internal;
 
 internal static class EnumerableExtensions
 {
+    [Pure]
     public static IEnumerable<object?> AsGeneric(this IEnumerable enumerable)
     {
         foreach (var item in enumerable)
@@ -10,6 +11,7 @@ internal static class EnumerableExtensions
         }
     }
 
+    [Pure]
     public static int Count(this IEnumerable enumerable)
     {
         if (enumerable is ICollection collection)
@@ -25,6 +27,7 @@ internal static class EnumerableExtensions
         return Enumerable.Count(enumerable.AsGeneric());
     }
 
+    [Pure]
     public static bool Any(this IEnumerable enumerable)
     {
         if (enumerable is ICollection collection)

--- a/src/Libraries/AssertNet/Properties/GlobalUsings.cs
+++ b/src/Libraries/AssertNet/Properties/GlobalUsings.cs
@@ -1,5 +1,6 @@
 global using AssertNet.AssertionTypes.Objects;
+global using AssertNet.Diagnostics;
+global using AssertNet.FailureHandlers;
 global using AssertNet.Failures;
 global using AssertNet.Helpers;
 global using AssertNet.Internal;
-global using AssertNet.FailureHandlers;


### PR DESCRIPTION
When methods are decorated with the `[Pure]` attribute, the compiler will remind users that the result of the call is not used, which indicates that the call made is pointless.

To help the analyzer doing this, all methods that can potentially be pure, are decorated. I added `[Assertion]` as alternative to `[Impure]` to make it easier to search for (impure) methods that are assertions.

Todo: we should not enable this rule for unit tests, but I did not create a separate `.editorconfig` nor `.globalconfig` file for unit tests only yet to disable this rule for those targets.