### PR TITLE
Assertions on being decorated or not

### DIFF
--- a/src/Libraries/AssertNet/AssertionTypes/Extensions/CustomAttributeProviderAssertions.cs
+++ b/src/Libraries/AssertNet/AssertionTypes/Extensions/CustomAttributeProviderAssertions.cs
@@ -25,7 +25,7 @@ public static class CustomAttributeProviderAssertions
         where TAssert : IAssertion<TSubject>
         where TSubject : ICustomAttributeProvider
     {
-        if (!assertion.Subject.GetCustomAttributes(true).Any(a => a.GetType() == attribute))
+        if (!assertion.Subject.GetCustomAttributes(attribute, true).Any())
         {
             assertion.Fail(new FailureBuilder("IsDecoratedWith()")
                 .Append(message)

--- a/src/Libraries/AssertNet/AssertionTypes/Extensions/CustomAttributeProviderAssertions.cs
+++ b/src/Libraries/AssertNet/AssertionTypes/Extensions/CustomAttributeProviderAssertions.cs
@@ -1,0 +1,73 @@
+namespace AssertNet.AssertionTypes;
+
+/// <summary>Assertions on <see cref="ICustomAttributeProvider" />.</summary>
+public static class CustomAttributeProviderAssertions
+{
+    /// <summary>Asserts that the subject is decorated with the specified attribute.</summary>
+    /// <param name="assertion">
+    /// The value under test to assert on.
+    /// </param>
+    /// <param name="attribute">
+    /// The attribute that is expected to be amongst the custom attributes.
+    /// </param>
+    /// <param name="message">
+    /// Custom message for the assertion failure.
+    /// </param>
+    /// <typeparam name="TAssert">
+    /// The type of the assertion.
+    /// </typeparam>
+    /// <typeparam name="TSubject">
+    /// The type of the subject.
+    /// </typeparam>
+    /// <returns>The current assertion.</returns>
+    [Assertion]
+    public static TAssert IsDecoratedWith<TAssert, TSubject>(this TAssert assertion, Type attribute, string? message = null)
+        where TAssert : IAssertion<TSubject>
+        where TSubject : ICustomAttributeProvider
+    {
+        if (!assertion.Subject.GetCustomAttributes(true).Any(a => a.GetType() == attribute))
+        {
+            assertion.Fail(new FailureBuilder("IsDecoratedWith()")
+                .Append(message)
+                .Append("Expecting", assertion.Subject)
+                .Append($"To be decorated with {attribute}, but was not")
+                .Finish());
+        }
+
+        return assertion;
+    }
+
+    /// <summary>Asserts that the subject is not decorated with the specified attribute.</summary>
+    /// <param name="assertion">
+    /// The value under test to assert on.
+    /// </param>
+    /// <param name="attribute">
+    /// The attribute that is expected not to be amongst the custom attributes.
+    /// </param>
+    /// <param name="message">
+    /// Custom message for the assertion failure.
+    /// </param>
+    /// <typeparam name="TAssert">
+    /// The type of the assertion.
+    /// </typeparam>
+    /// <typeparam name="TSubject">
+    /// The type of the subject.
+    /// </typeparam>
+    /// <returns>The current assertion.</returns>
+    [Assertion]
+    public static TAssert IsNotDecoratedWith<TAssert, TSubject>(this TAssert assertion, Type attribute, string? message = null)
+        where TAssert : IAssertion<TSubject>
+        where TSubject : ICustomAttributeProvider
+    {
+        if (assertion.Subject.GetCustomAttributes(true).Any(a => a.GetType() == attribute))
+        {
+            assertion.Fail(new FailureBuilder("IsDecoratedWith()")
+                .Append(message)
+                .Append("Expecting", assertion.Subject)
+                .Append($"To be decorated with {attribute}, but was not")
+                .Finish());
+        }
+
+        return assertion;
+    }
+}

--- a/src/Tests/AssertNet.Tests/AssertionTypes/CustomAttributeProvider_assertions.cs
+++ b/src/Tests/AssertNet.Tests/AssertionTypes/CustomAttributeProvider_assertions.cs
@@ -21,9 +21,11 @@ public class IsDecoratedWith
         [Fact]
         public void Decorated_subject()
         {
-            var member = typeof(Parent).GetMethod(nameof(Parent.ToString));
-            //var assertion = Asserts.That(member);
-            //.IsDecoratedWith(typeof(PureAttribute)));
+            var member = typeof(Parent).GetMethod(nameof(Parent.ToString))!;
+            IAssertion<MemberInfo> assertion = Asserts.That(member);
+
+            CustomAttributeProviderAssertions.IsDecoratedWith<IAssertion<MemberInfo>, MemberInfo>(assertion, typeof(PureAttribute));
+            //assertion.IsDecoratedWith(typeof(PureAttribute), "");
         }
     }
 }

--- a/src/Tests/AssertNet.Tests/AssertionTypes/CustomAttributeProvider_assertions.cs
+++ b/src/Tests/AssertNet.Tests/AssertionTypes/CustomAttributeProvider_assertions.cs
@@ -1,0 +1,39 @@
+using AssertNet;
+using AssertNet.AssertionTypes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CustomAttributeProvider_assertions;
+
+public class IsDecoratedWith
+{
+    public class Fails
+    {
+        
+
+    }
+
+    public class Guards
+    {
+        [Fact]
+        public void Decorated_subject()
+        {
+            var member = typeof(Parent).GetMethod(nameof(Parent.ToString));
+            //var assertion = Asserts.That(member);
+            //.IsDecoratedWith(typeof(PureAttribute)));
+        }
+    }
+}
+
+file class Parent
+{
+    /// <inheritdoc />
+    /// <remarks>Inheritable attribute.</remarks>
+    [Pure]
+    public override string ToString() => nameof(Parent);
+}
+
+file sealed class Child : Parent { }


### PR DESCRIPTION
Unfortunately so far:

>The type arguments for method 'CustomAttributeProviderAssertions.IsDecoratedWith<TAssert, TSubject>(TAssert, Type, string?)' cannot be inferred from the usage. Try specifying the type arguments explicitly.